### PR TITLE
Refactor Application Directory

### DIFF
--- a/app/common/utils/app-directory.js
+++ b/app/common/utils/app-directory.js
@@ -1,0 +1,14 @@
+/**
+ * Application directory.
+ *
+ * Single access point for the application's user directory's path.
+ */
+
+'use strict';
+
+var os = require('os');
+var path = require('path');
+
+var appDirectory = path.join(os.homedir(), '.coinstac');
+
+module.exports = appDirectory;

--- a/app/index.jade
+++ b/app/index.jade
@@ -7,6 +7,5 @@ html(lang="en")
         #app
         script(type='text/javascript').
             window.COINS_ENV = '#{coinsEnv}';
-            window.coinstacDir = '#{coinstacDir}';
         script(type='text/javascript', src="js/babel-browser-polyfill.js")
         script(type='text/javascript', src=entryUrl)

--- a/app/js/index.js
+++ b/app/js/index.js
@@ -8,7 +8,6 @@ import { Provider } from 'react-redux';
 import configureStore from './store/configureStore';
 import routes from './routes';
 
-app.coinstacDir = window.coinstacDir;
 app.isDev = window.COINS_ENV === 'development';
 app.store = configureStore();
 

--- a/app/js/services/db-registry.js
+++ b/app/js/services/db-registry.js
@@ -5,8 +5,11 @@ var config = require('config');
 var _ = require('lodash');
 var url = require('url');
 var app = require('ampersand-app');
+
+var appDirectory = require('../../common/utils/app-directory');
+
 Pouchy.PouchDB.defaults({
-    prefix: app.coinstacDir
+    prefix: appDirectory
 });
 
 var LOCAL_STORES = ['projects'];
@@ -71,15 +74,15 @@ dbs.register = function(opts) {
     var dbConnStr = opts.name || opts.url;
     // assert db can register, and configure its domain
     if (LOCAL_STORES.some(function(format) { return _.contains(dbConnStr, format); })) {
-        if (!app.coinstacDir) {
+        if (appDirectory) {
             throw new TypeError('path must be specified for db');
         }
-        opts.path = app.coinstacDir;
+        opts.path = appDirectory;
     } else if (REMOTE_STORES_SYNC_OUT.some(function(format) { return _.contains(dbConnStr, format); })) {
-        if (!app.coinstacDir) {
+        if (appDirectory) {
             throw new TypeError('path must be specified for db');
         }
-        opts.path = app.coinstacDir;
+        opts.path = appDirectory;
         opts.replicate = 'both'; // @TODO outbound replications to happen manually using `replicate.to()`
     } else if (REMOTE_STORES_SYNC_IN.some(function(format) { return _.contains(dbConnStr, format); })) {
         opts.replicate = 'in';

--- a/app/main/utils/build-index.js
+++ b/app/main/utils/build-index.js
@@ -9,7 +9,6 @@ module.exports = function() {
     locals = {
         pageTitle: 'COINSTAC',
         coinsEnv: process.env.COINS_ENV,
-        coinstacDir: global.coinstacDir
     };
 
     if (process.env.COINS_ENV === 'development') {

--- a/app/main/utils/define-globals.js
+++ b/app/main/utils/define-globals.js
@@ -2,5 +2,4 @@
 module.exports = function() {
     var os = require('os');
     var path = require('path');
-    global.coinstacDir = path.join(os.homedir(), '.coinstac');
 };

--- a/app/main/utils/upsert-coinstac-user-dir.js
+++ b/app/main/utils/upsert-coinstac-user-dir.js
@@ -1,11 +1,14 @@
 var fs = require('fs');
+
+var appDirectory = require('../../common/utils/app-directory');
+
 module.exports = function() {
     var stat;
     try {
-        stat = fs.statSync(global.coinstacDir);
+        stat = fs.statSync(appDirectory);
     } catch (err) {
         if (err.code === 'ENOENT') {
-            return fs.mkdirSync(global.coinstacDir);
+            return fs.mkdirSync(appDirectory);
         }
         throw err;
     }

--- a/test/render/db-registry.js
+++ b/test/render/db-registry.js
@@ -6,7 +6,6 @@ var dbs = require(path.join(process.cwd(), 'app/js/services/db-registry.js'));
 var Pouchy = require('pouchy');
 
 var app = require('ampersand-app');
-app.coinstacDir = global.coinstacDir;
 
 test('render process, db-registry, general `.get()` ops', function(t) {
     var pdb = dbs.get('projects');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,8 @@ var getExternals = function() {
         ipc: 'commonjs ipc',
         remote: 'commonjs remote',
         path: 'commonjs path',
-        config: 'commonjs config'
+        config: 'commonjs config',
+        os: 'commonjs os',
     };
     Object.keys(require('./package.json').dependencies).forEach(function(packageName) {
         if (internals.some(function(internal) { return packageName.match(internal) })) {


### PR DESCRIPTION
This PR moves access of the application’s storage directory into a common location. I looked into what Atom does and they do [something similar](https://github.com/atom/apm/blob/064550569962d43a2967e04f273f13b1e28c01d5/src/apm.coffee#L8-L12), although this responsibility is delegated to their APM package manager.

Some benefits:

* Avoid globals
* Avoid race conditions where `app.coinstacDir` is `undefined` in prior executed modules
* Promote modular structure
