### PR TITLE
bugfix/remove-error-suppressing-handlers

### DIFF
--- a/app/js/actions/consortium.js
+++ b/app/js/actions/consortium.js
@@ -15,8 +15,7 @@ export function fetchConsortium(id) {
     return dispatch => {
         dispatch(requestConsortium(id));
         consortium.get(id)
-            .then(consortium => dispatch(receiveConsortium(consortium)))
-            .catch(error => dispatch(consortiumError(error)));
+            .then(consortium => dispatch(receiveConsortium(consortium)));
     };
 }
 
@@ -31,13 +30,6 @@ function receiveConsortium(consortium) {
     return {
         consortium,
         type: CONSORTIUM_RECEIVE,
-    };
-}
-
-export function consortiumError(error) {
-    return {
-        error,
-        type: CONSORTIUM_ERROR,
     };
 }
 
@@ -208,8 +200,7 @@ export function fetchResults(consortiumId) {
     return dispatch => {
         dispatch(requestResults(consortiumId));
         getResults(consortiumId)
-            .then(results => dispatch(receiveResults(consortiumId, results)))
-            .catch(error => dispatch(consortiumError(error)));
+            .then(results => dispatch(receiveResults(consortiumId, results)));
     }
 }
 

--- a/app/js/middleware/consortium.js
+++ b/app/js/middleware/consortium.js
@@ -26,21 +26,20 @@ export default store => next => action => {
     action.user = { username };
 
     const nextAction = () => next(action);
-    const errorHandler = error => next(consortiumError(error));
 
     switch (type) {
         case CONSORTIUM_ADD_USER:
             return consortium.addUser(consortiumId, username)
-                .then(nextAction, errorHandler);
+                .then(nextAction);
         case CONSORTIUM_REMOVE_USER:
             return consortium.removeUser(consortiumId, username)
-                .then(nextAction, errorHandler);
+                .then(nextAction);
         case CONSORTIUM_ADD_ANALYSIS:
             return consortium.addAnalysis(consortiumId, analysis)
-                .then(nextAction, errorHandler);
+                .then(nextAction);
         case CONSORTIUM_REMOVE_ANALYSIS:
             return consortium.removeAnalysis(consortiumId, id)
-                .then(nextAction, errorHandler);
+                .then(nextAction);
         default:
             return nextAction();
     }


### PR DESCRIPTION
#### asana
https://app.asana.com/0/45796090191289/68281845672380

# problem statement
- `consortiumError / CONSORTIUM_ERROR` don't handle the error, but catch it, and swallow it

# solution
for now, let the app error out

# long term
ideas:
- perhaps we can figure out a way to determine if the error happened during a route change, then if so, if the error is caught by the global handler, route _back_?
- have a convention where the root app state gets a state attr of `error/unhandled_error/whatever`, and on root component render, posts an alert to the user
    - this sort of feels like like an anti-pattern. ~ i don't think we'd do this for sync errors, why do it differently for async.  perhaps the correct solution is to let the app error out if we're not going to handle it, OR, just handle the darn thing!~ I take that back.  The issue is generally that a service is down or misconfigured.  We very well may do something like that for sync errors, too.
- build a convention to handle async, middleware based action errors where the _target_ app state gets an `error` prop
    - same as above, but on the target app state, vs. top level global app state

Maybe we override `render` to:

```js
React.prototype.render = function() {
    if (state.unhandledErrors.length) {
        app.notify(...);
    }
    React.prototype.render.apply(this, arguments);
}
```

I'm not attached to any of these ideas, but they're food for thought.  Just as we do `process.on('uncaughtException')`, it'd be nice to be able to possibly reflect that there was an issue in the UI too