### PR TITLE
Fully resolve a declaration's computation path.

### DIFF
--- a/packages/coinstac-simulator/src/index.js
+++ b/packages/coinstac-simulator/src/index.js
@@ -97,7 +97,10 @@ const exportList = {
           undefined;
 
         return Promise.all([
-          declaration.computationPath,
+          path.resolve(
+            path.dirname(require.resolve(declarationPath)),
+            declaration.computationPath
+          ),
           local,
           remote,
           !!declaration.verbose,

--- a/packages/coinstac-simulator/test/coinstac-simulator.js
+++ b/packages/coinstac-simulator/test/coinstac-simulator.js
@@ -200,7 +200,10 @@ tape('gets declaration by path', t => {
       t.deepEqual(
         declaration,
         {
-          computationPath: './path/to/computation.js',
+          computationPath: path.resolve(
+            __dirname,
+            'mocks/path/to/computation.js'
+          ),
           local: [{}, {}, {}, {}, {}, {}, {}, {}, {}, {}],
           remote: undefined,
           verbose: false,
@@ -215,8 +218,11 @@ tape('gets declaration by path', t => {
     .then(declaration => {
       t.equal(
         declaration.computationPath,
-        './path/to/computation.js',
-        'passes computation path'
+        path.resolve(
+          __dirname,
+          'mocks/path/to/computation.js'
+        ),
+        'passes resolved computation path'
       );
       t.deepEqual(
         declaration.local,

--- a/packages/coinstac-simulator/test/mocks/good-declaration-2.js
+++ b/packages/coinstac-simulator/test/mocks/good-declaration-2.js
@@ -1,7 +1,9 @@
 'use strict';
 
+const path = require('path');
+
 module.exports = {
-  computationPath: './path/to/computation.js',
+  computationPath: path.join(__dirname, 'path', 'to', 'computation.js'),
   local: [{
     x: Promise.resolve('how'),
     y: 'who',


### PR DESCRIPTION
- **Problem:** A declaration’s `computationPath` property isn’t always resolved to the computation file’s location.
- **Solution:** Use Node.js’s built-in module and path resolution to _deal wit it_.

This closes #37.
