### PR TITLE
Make UI clean scripts cross-environment

### DIFF
--- a/packages/coinstac-client-core/src/index.js
+++ b/packages/coinstac-client-core/src/index.js
@@ -61,6 +61,15 @@ const ProjectServices = require('./sub-api/project-service');
  */
 class CoinstacClient {
   /**
+   * Get the default application storage directory.
+   *
+   * @returns {string}
+   */
+  static getDefaultAppDirectory() {
+    return path.join(osHomedir(), '.coinstac');
+  }
+
+  /**
    * Sanitize username for use as a directory.
    * @private
    *
@@ -82,7 +91,8 @@ class CoinstacClient {
     }
     this.dbConfig = opts.db;
     this.storage = opts.storage;
-    this.appDirectory = opts.appDirectory || path.join(osHomedir(), '.coinstac');
+    this.appDirectory = opts.appDirectory ||
+      CoinstacClient.getDefaultAppDirectory();
     this.halfpennyBaseUrl = opts.hp;
     this.logger = opts.logger || new Logger({ transports: [new Console()] });
 

--- a/packages/coinstac-ui/package.json
+++ b/packages/coinstac-ui/package.json
@@ -77,8 +77,8 @@
     "build": "npm run build:webpack && node ./scripts/build.js",
     "start": "webpack && cross-env STEELPENNY_URL='https://coins-api.mrn.org/api/v1.3.0' electron . --log-level=debug",
     "build-native": "node ./scripts/build-native.js",
-    "clean": "rm -rf ~/.coinstac",
-    "clean-db": "find ~/.coinstac/* ! -name computations -maxdepth 0 -exec rm -rf '{}' \\;",
+    "clean": "node scripts/clean.js",
+    "clean:db": "node scripts/clean-db.js",
     "docs": "mkdir -p docs && jsdoc -t ./node_modules/minami -d docs -R README.md -r src/",
     "test": "nyc --reporter=lcov --check-coverage --lines=1 --functions=1 --branches=1 babel-node test/",
     "watch": "webpack-dashboard -p 3001 -- node webpack-dev-server.js"

--- a/packages/coinstac-ui/scripts/clean-db.js
+++ b/packages/coinstac-ui/scripts/clean-db.js
@@ -1,0 +1,36 @@
+'use strict';
+// find ~/.coinstac/* ! -name computations -maxdepth 0 -exec rm -rf '{}' \\;
+
+const bluebird = require('bluebird');
+const CoinstacClient = require('coinstac-client-core');
+const compact = require('lodash/compact');
+const fs = require('fs');
+const path = require('path');
+const rimraf = require('rimraf');
+
+const dir = CoinstacClient.getDefaultAppDirectory();
+const rimrafAsync = bluebird.promisify(rimraf);
+const statAsync = bluebird.promisify(fs.stat);
+
+/* eslint-disable no-console */
+console.log('Removing local dbs…');
+
+bluebird.promisify(fs.readdir)(dir)
+  .then(files => Promise.all(files.map(file => {
+    const fullPath = path.join(dir, file);
+
+    return statAsync(fullPath).then(stats => {
+      return stats.isDirectory() && file !== 'computations' ?
+        fullPath :
+        undefined;
+    });
+  })))
+  .then(compact)
+  .then(fullPaths => Promise.all(fullPaths.map(fullPath => {
+    return rimrafAsync(fullPath).then(() => {
+      console.log(`Removed ${fullPath}`);
+    });
+  })))
+  .catch(console.error);
+/* eslint-enable no-console */
+

--- a/packages/coinstac-ui/scripts/clean.js
+++ b/packages/coinstac-ui/scripts/clean.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const bluebird = require('bluebird');
+const CoinstacClient = require('coinstac-client-core');
+const rimraf = require('rimraf');
+
+const dir = CoinstacClient.getDefaultAppDirectory();
+
+/* eslint-disable no-console */
+console.log(`Removing ${dir} …`);
+
+bluebird.promisify(rimraf)(dir)
+  .then(() => console.log('Removed!'))
+  .catch(console.error);
+/* eslint-enable no-console */
+


### PR DESCRIPTION
This addresses #22 by moving ‘em scripts to Node.js files. Easy!
