### PR TITLE
✨ Freshen Builds

### DIFF
--- a/packages/coinstac-ui/package.json
+++ b/packages/coinstac-ui/package.json
@@ -75,7 +75,7 @@
   },
   "scripts": {
     "build:webpack": "cross-env NODE_ENV=production webpack",
-    "build": "npm run build:webpack && node ./scripts/build.js",
+    "build": "scripts/build-setup.sh && npm run build:webpack && node ./scripts/build.js",
     "start": "webpack && cross-env STEELPENNY_URL='https://coins-api.mrn.org/api/v1.3.0' electron . --log-level=debug",
     "build-native": "node ./scripts/build-native.js",
     "clean": "node scripts/clean.js",

--- a/packages/coinstac-ui/scripts/build-setup.sh
+++ b/packages/coinstac-ui/scripts/build-setup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+rm -rf node_modules/coinstac-{common,client-core}
+mkdir -p node_modules/coinstac-{common,client-core}
+
+cp -r ../coinstac-common/{package.json,src} ./node_modules/coinstac-common/
+cp -r ../coinstac-client-core/{bin,config.js,package.json,src} ./node_modules/coinstac-client-core/
+
+npm install
+


### PR DESCRIPTION
This ensures that the _freshest_ coinstac-common and coinstac-client-core are bundled within the UI before its built. This is easier then publishing these packages every time before testing a build.
- **Problem:** Builds rely on published packages.
- **Solution:** Bash script ‘em to copy that source
- **Testing:**
  1. Check out branch
  2. Run `npm run build` in _packages/coinstac-ui/_
  3. Test out the build!
