### PR TITLE
Pipeline step persistence

### DIFF
--- a/packages/coinstac-client-core/bin/coinstac-client-core
+++ b/packages/coinstac-client-core/bin/coinstac-client-core
@@ -2,6 +2,7 @@
 'use strict';
 
 const assign = require('lodash/assign');
+const bluebird = require('bluebird');
 const common = require('coinstac-common');
 const CoinstacClient = require('../src/index');
 const { compact, flatten } = require('lodash');
@@ -41,6 +42,22 @@ let username;
 function errorHandler(...errors) {
   errors.forEach(error => logger.error(error));
   process.exit(1);
+}
+
+/**
+ * @param {string[]} dirs
+ * @returns {Promise}
+ */
+function getFiles(dirs) {
+  const globAsync = bluebird.promisify(glob);
+  const statAsync = bluebird.promisify(fs.stat);
+
+  return Promise.all(dirs.map(dir => globAsync(dir)))
+    .then(flatten)
+    .then(files => Promise.all(files.map(file => {
+      return statAsync(file).then(stats => stats.isFile() ? file : undefined);
+    })))
+    .then(compact);
 }
 
 process.on('uncaughtException', errorHandler);
@@ -149,44 +166,24 @@ program
 
     logger.info('Retrieving files...');
 
-    return Promise.all(program.args.map(dir => {
-      return new Promise((resolve, reject) => {
-        glob(dir, (error, files) => {
-          if (error) {
-            reject(error);
-          } else {
-            resolve(files);
-          }
-        });
-      });
-    }))
-      .then(flatten)
-      .then(files => Promise.all(files.map(file => {
-        return new Promise((resolve, reject) => {
-          fs.stat(file, (error, stats) => {
-            if (error) {
-              reject(error);
-            }
-
-            if (stats.isFile()) {
-              resolve(file);
-            }
-
-            resolve();
-          });
-        });
-      })))
-      .then(compact)
-      .then(client.projects.getFileStats);
+    return Promise.all([
+      getFiles(program.args).then(client.projects.getFileStats),
+      client.projects.getCSV(program.metafile),
+    ]);
   })
-  .then(files => {
+  .then(([files, metaFile]) => {
     const consortiumId = program.consortium;
     logger.info('Saving project...');
 
     const project = new Project({
       consortiumId,
-      files: files, // eslint-disable-line object-shorthand
-      metaFile: program.metafile,
+      files,
+      metaCovariateMapping: {
+        1: 0,
+        2: 1,
+      },
+      metaFile,
+      metaFilePath: program.metafile,
       name: `${username}'s project`,
     });
 

--- a/packages/coinstac-client-core/bin/coinstac-client-core
+++ b/packages/coinstac-client-core/bin/coinstac-client-core
@@ -55,7 +55,7 @@ function getFiles(dirs) {
   return Promise.all(dirs.map(dir => globAsync(dir)))
     .then(flatten)
     .then(files => Promise.all(files.map(file => {
-      return statAsync(file).then(stats => stats.isFile() ? file : undefined);
+      return statAsync(file).then(stats => (stats.isFile() ? file : undefined));
     })))
     .then(compact);
 }

--- a/packages/coinstac-client-core/test/e2e/client.js
+++ b/packages/coinstac-client-core/test/e2e/client.js
@@ -1,0 +1,189 @@
+'use strict';
+
+const coinstacCommon = require('coinstac-common');
+const CoinstacClient = require('../../src/index.js');
+const fs = require('fs');
+const glob = require('glob');
+const path = require('path');
+const PouchDBAdapterMemory = require('pouchdb-adapter-memory');
+const Project = require('coinstac-common').models.Project;
+const ProjectService = require('../../src/sub-api/project-service.js');
+const { promisify } = require('bluebird');
+const Storage = require('dom-storage');
+const winston = require('winston');
+
+coinstacCommon.services.dbRegistry.DBRegistry.Pouchy.PouchDB.plugin(
+  PouchDBAdapterMemory
+);
+
+const getSyncedDatabase = coinstacCommon.utils.getSyncedDatabase;
+
+const logger = new winston.Logger({
+  level: 'info',
+  transports: [new winston.transports.Console()],
+});
+
+const STORAGE_DIR = path.join(__dirname, '..', '.tmp');
+
+function getFilesFromDir(dir) {
+  const statAsync = promisify(fs.stat);
+
+  return promisify(glob)(dir)
+    .then(files => Promise.all(files.map(file => {
+      return statAsync(file).then(stats => ({ file, stats }));
+    })))
+    .then(results => results.reduce((memo, { file, stats }) => {
+      return stats.isFile() ? memo.concat(file) : memo;
+    }, []))
+    .then(ProjectService.prototype.getFileStats);
+}
+
+function getQueueEndStopper(count, fn) {
+  let endCount = 0;
+
+  return function queEndStopper(runId) {
+    endCount++;
+
+    logger.info('queue:end', `runId: ${runId}`, `count: ${endCount}`);
+
+    if (endCount === count) {
+      const value = fn();
+
+      /**
+       * Ensure process exists.
+       *
+       * @todo Determine if this is necessary
+       */
+      if (typeof value === 'object' && value.then & value.catch) {
+        value.then(process.exit);
+      } else {
+        process.exit();
+      }
+    }
+  };
+}
+
+function start({ consortiumId, files, initiate, metaFilePath, username }) {
+  const client = new CoinstacClient({
+    appDirectory: STORAGE_DIR,
+    db: {
+      local: {
+        pouchConfig: {
+          adapter: 'memory',
+        },
+      },
+      noURLPrefix: true,
+      path: path.join(STORAGE_DIR, 'db'),
+      remote: {
+        db: {
+          hostname: 'localhost',
+          pathname: '',
+          port: 5984,
+          protocol: 'http',
+        },
+        pouchConfig: {
+          adapter: 'memory',
+        },
+      },
+    },
+    hp: 'http://localhost:8800',
+    logger,
+    storage: new Storage(null, { strict: true }),
+  });
+
+  logger.info('Initializing client...');
+
+  return client.initialize({
+    password: 'test',
+    username,
+  })
+    .then(() => {
+      logger.info('Client initialized');
+
+      client.pool.events.on(
+        'queue:end',
+        getQueueEndStopper(6, client.teardown.bind(client))
+      );
+
+      return Promise.all([
+        getFilesFromDir(files),
+        client.projects.getCSV(metaFilePath),
+        getSyncedDatabase(
+          client.dbRegistry,
+          `remote-consortium-${consortiumId}`
+        ),
+      ]);
+    })
+    .then(([files, metaFile, remoteDb]) => {
+      logger.info('Saving project...');
+
+      return Promise.all([
+        client.dbRegistry.get('projects').save(
+          new Project({
+            consortiumId,
+            files,
+            metaCovariateMapping: {
+              1: 0,
+              2: 1,
+            },
+            metaFile: JSON.parse(metaFile),
+            metaFilePath,
+            name: 'test-project',
+          }).serialize()
+        ),
+        remoteDb.all(),
+      ]);
+    })
+    .then(([project, remoteDocs]) => {
+      logger.info('Starting computation...');
+
+      if (!remoteDocs.length) {
+        throw new Error('No remote docs!');
+      }
+
+      return client.computations.joinRun({
+        consortiumId,
+        projectId: project._id,
+        runId: remoteDocs[0]._id,
+      });
+    });
+}
+
+function getMessageSender(message) {
+  return function messageSender(data) {
+    const toSend = {
+      data,
+      response: message.command,
+    };
+
+    logger.info('Sending IPC message:', toSend);
+    process.send(toSend);
+  };
+}
+
+process.on('uncaughtException', error => {
+  logger.error(error);
+  process.exit(1);
+});
+
+process.on('unhandledRejection', (reason, p) => {
+  logger.error('Unhandled Rejection at: Promise ', p, ' reason: ', reason);
+  process.exit(1);
+});
+
+process.on('message', message => {
+  const messageSender = getMessageSender(message);
+  const { command, data } = message;
+
+  logger.info('Received IPC message:', message);
+
+  switch (command) {
+    case 'READY':
+      return messageSender();
+    case 'START':
+      return start(data).then(messageSender);
+    default:
+      return messageSender('UNKNOWN COMMAND');
+  }
+});
+

--- a/packages/coinstac-client-core/test/e2e/client.js
+++ b/packages/coinstac-client-core/test/e2e/client.js
@@ -63,7 +63,7 @@ function getQueueEndStopper(count, fn) {
   };
 }
 
-function start({ consortiumId, files, initiate, metaFilePath, username }) {
+function start({ consortiumId, files, metaFilePath, username }) {
   const client = new CoinstacClient({
     appDirectory: STORAGE_DIR,
     db: {

--- a/packages/coinstac-client-core/test/e2e/index.js
+++ b/packages/coinstac-client-core/test/e2e/index.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const fork = require('child_process').fork;
+const os = require('os');
+const path = require('path');
+const winston = require('winston');
+
+const CONSORTIUM_ID = 'test';
+const usernames = ['charmander', 'pikachu'];
+const kids = [];
+
+process.on('exit', () => kids.forEach(kid => kid && kid.kill()));
+
+function getLogger(pid, level = 'info') {
+  return function logger(data) {
+    winston.log(level, `[${pid}]: ${data.toString()}`);
+  };
+}
+
+function getChild() {
+  return new Promise((resolve, reject) => {
+    const child = fork(
+      path.join(__dirname, 'client.js'), {
+        silent: true,
+      });
+    const logger = getLogger(child.pid);
+    const errorLogger = getLogger(child.pid, 'error');
+
+    function errorHandler(error) {
+      errorLogger(error);
+      reject(error);
+    }
+
+    child.stderr.on('data', errorLogger);
+    child.stdout.on('data', logger);
+    child.on('close', code => {
+      if (code) {
+        errorLogger(`Exited with code ${code}`);
+      } else {
+        logger('Exited');
+      }
+    });
+    child.on('error', errorHandler);
+
+    child.on('message', m => {
+      if (m.response === 'READY') {
+        child.removeListener('error', errorHandler);
+        resolve(child);
+      }
+    });
+
+    child.send({
+      command: 'READY',
+    });
+  });
+}
+
+function startChild(
+  child,
+  { consortiumId, files, initiate, metaFilePath, username }
+) {
+  return new Promise(resolve => {
+    child.on('message', m => {
+      if (m.response === 'START') {
+        resolve(child);
+      }
+    });
+
+    child.send({
+      command: 'START',
+      data: {
+        consortiumId,
+        files,
+        initiate,
+        metaFilePath,
+        username,
+      },
+    });
+  });
+}
+
+Promise.all(usernames.map(getChild))
+  .then(children => {
+    children.forEach(kid => kids.push(kid));
+
+    return Promise.all(children.map((child, index) => startChild(child, {
+      consortiumId: CONSORTIUM_ID,
+      files: path.join(
+        os.homedir(),
+        `/Downloads/thalamus-analysis/{controls,patients}-${index}/*.txt`
+      ),
+      initiate: index === 0,
+      metaFilePath: path.join(
+        os.homedir(),
+        `/Downloads/thalamus-analysis/manifest-${index}.csv`
+      ),
+      username: usernames[index],
+    })));
+  })
+  .catch(winston.error);
+


### PR DESCRIPTION
- **Problem:** Re-instantiated pipelines don’t use their persisted state, instead starting at the first step.
- **Solution:** Ensure the local result document’s is used when creating a `Pipeline` (specifically 6d17cd44f7ebb36baa8fd4c67ef8044d7f7e13c2).
- **Testing:** ?

Closes #79.
