### PR TITLE
Computation inputs for non-owners

### DIFF
--- a/packages/coinstac-ui/app/render/components/consortium/consortium-computation-inputs-viewer.js
+++ b/packages/coinstac-ui/app/render/components/consortium/consortium-computation-inputs-viewer.js
@@ -1,0 +1,45 @@
+import React, { PropTypes } from 'react';
+
+/**
+ * @param {Object} props
+ * @param {Object[]} props.inputs
+ * @param {Object[]} props.values
+ * @returns {React.Component}
+ */
+export default function ConsortiumComputationInputsViewer(props) {
+  const { inputs, values } = props;
+
+  return (
+    <div className="consortium-computation-inputs-viewer panel panel-default">
+      <div className="panel-heading">
+        <h2 className="panel-title">Computation Inputs</h2>
+      </div>
+      <div className="panel-body">
+        <ul className="list-unstyled">
+          {inputs.map((input, index) => {
+            let value;
+
+            if (!(index in values)) {
+              value = '';
+            } else if (input.type === 'covariates') {
+              value = values[index].map(v => v.name).join(', ');
+            } else {
+              value = values[index].toString();
+            }
+
+            return (
+              <li key={index}>
+                <strong>{input.label}:</strong> {value}
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+ConsortiumComputationInputsViewer.propTypes = {
+  inputs: PropTypes.arrayOf(PropTypes.object).isRequired,
+  values: PropTypes.array.isRequired,
+};

--- a/packages/coinstac-ui/app/render/components/consortium/consortium.js
+++ b/packages/coinstac-ui/app/render/components/consortium/consortium.js
@@ -1,6 +1,8 @@
 import React, { Component, PropTypes } from 'react';
 import { Button } from 'react-bootstrap';
 
+import ConsortiumComputationInputsViewer from
+  './consortium-computation-inputs-viewer';
 import ConsortiumForm from './consortium-form';
 import ConsortiumTags from './consortium-tags';
 import ConsortiumResults from './consortium-results';
@@ -112,6 +114,23 @@ export default class Consortium extends Component {
       );
     }
 
+    const inputsViewerProps = {};
+
+    if (consortium.activeComputationId) {
+      const activeComputation = computations.find(({ _id }) => {
+        return _id === consortium.activeComputationId;
+      });
+
+      if (
+        activeComputation &&
+        Array.isArray(activeComputation.inputs) &&
+        activeComputation.inputs.length
+      ) {
+        inputsViewerProps.inputs = activeComputation.inputs[0];
+        inputsViewerProps.values = consortium.activeComputationInputs[0];
+      }
+    }
+
     // TODO: Add active computation display for members
     return (
       <div className="consortium-details">
@@ -120,6 +139,7 @@ export default class Consortium extends Component {
         </div>
         <p className="lead section">{consortium.description}</p>
         <ConsortiumTags tags={consortium.tags} />
+        <ConsortiumComputationInputsViewer {...inputsViewerProps} />
       </div>
     );
   }


### PR DESCRIPTION
- **Problem:** Non-consortium-owners can't see computation inputs.
- **Solution:** Add ’em back in!
- **Testing:**
  1. Create a consortium
  2. Log in as another user
  3. Join consortium
  4. View the inputs: 
     ![comp-inputs](https://cloud.githubusercontent.com/assets/1858316/19787413/6f984234-9c57-11e6-973a-08f421fbb7f9.jpg)

Closes #61.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/173590139517418/203827019150220)
