### PR TITLE
Speedup: remove hist addition to speedup runs

### DIFF
--- a/packages/coinstac-common/src/models/computation/computation-result.js
+++ b/packages/coinstac-common/src/models/computation/computation-result.js
@@ -10,7 +10,6 @@ const memoize = require('lodash/memoize');
  * @extends PouchDocument
  * @description Generic ComputationResult result container.
  * @property {*} data
- * @property {array} history previous computation result (data only)
  * @property {object} pipelineState snapshot of latest pipeline state
  * @property {string} computationId _id of computation definition executed
  * @property {string} runId non-persisted attr used as the unique identifier for

--- a/packages/coinstac-common/src/models/computation/computation-result.js
+++ b/packages/coinstac-common/src/models/computation/computation-result.js
@@ -78,7 +78,6 @@ ComputationResult.prototype._extractRunId = memoize(function _extractRunId(_id) 
 ComputationResult.schema = Object.assign({
   data: joi.any(),
   error: joi.object(),
-  history: joi.array().default([]),
   pipelineState: joi.object().keys({
     step: joi.number(),
     inProgress: joi.boolean(),

--- a/packages/coinstac-common/src/models/pipeline/runner/pipeline-runner.js
+++ b/packages/coinstac-common/src/models/pipeline/runner/pipeline-runner.js
@@ -284,9 +284,6 @@ class PipelineRunner extends Base {
     // build result history on existing results
     this.hasPersistedResult = true;
     assign(this.result, doc, patch);
-    if (doc.data !== undefined && doc.data !== null) {
-      this.result.history = doc.history.concat(doc.data);
-    }
     return this._persistResult(db);
   }
 

--- a/packages/coinstac-common/test/models/computation/computation-result.js
+++ b/packages/coinstac-common/test/models/computation/computation-result.js
@@ -18,15 +18,12 @@ const genOpts = (opts) => {
 test('constructor - basic', t => {
   const minFullOptsPatch = {
     data: 'a',
-    history: [],
     pipelineState: { step: 0, inProgress: false },
   };
   const richFullOptsPatch = {
     data: { a: ['b'] },
-    history: ['c', 'd'],
     pipelineState: { step: 1, inProgress: true },
   };
-  const errorOptsPatch1 = { history: {} };
   const errorOptsPatch2 = { pipelineState: null };
 
   t.ok(
@@ -36,10 +33,6 @@ test('constructor - basic', t => {
   t.ok(
         new ComputationResult(genOpts(richFullOptsPatch)),
         'fully loaded ComputationResult ok, 2'
-    );
-  t.throws(
-        () => (new ComputationResult(genOpts(errorOptsPatch1))),
-        'bogus data rejected (.history)'
     );
   t.throws(
         () => (new ComputationResult(genOpts(errorOptsPatch2))),

--- a/packages/coinstac-common/test/models/pipeline/runner/pipeline-runner.js
+++ b/packages/coinstac-common/test/models/pipeline/runner/pipeline-runner.js
@@ -65,27 +65,6 @@ test('saveResult - basic - error', t => {
   .then(t.end, t.end);
 });
 
-test('saveResult - queue simultaneous saves, history OK', t => {
-  const runner = new Runner(runnerUtils.basicOpts());
-  const db = runnerUtils.getDB('history_test_db');
-  t.plan(5);
-  Promise.resolve()
-  .then(() => runner.saveResult(db, { first: 1 }))
-  .then(() => db.all().then((docs) => docs[0]))
-  .then((doc) => {
-    t.notOk(doc.history.length, 'no history after first save');
-    t.equal(doc.data.first, 1, 'first-to-queue data saved on concurrent save request');
-  })
-  .then(() => runner.saveResult(db, { second: 2 }))
-  .then(() => db.all().then((docs) => docs[0]))
-  .then((doc) => {
-    t.equal(doc.history.length, 1, 'history maintained');
-    t.deepEqual(doc.history, [{ first: 1 }]);
-    t.deepEqual(doc.data, { second: 2 });
-  })
-  .then(t.end, t.end);
-});
-
 test('getPreviousResult', t => {
   const runnerOpts = runnerUtils.basicOpts();
   const db = runnerUtils.getDB('prev_results_db');

--- a/packages/coinstac-ui/app/render/components/consortium/consortium-result.js
+++ b/packages/coinstac-ui/app/render/components/consortium/consortium-result.js
@@ -22,7 +22,6 @@ export default function ConsortiumResult({
   computation,
   complete,
   data,
-  history,
   pipelineState,
   userErrors,
   usernames,
@@ -55,7 +54,6 @@ export default function ConsortiumResult({
     <div>
       <h3 className="h4">Computation state:</h3>
       <ul>
-        <li>Iteration #: <strong>{history.length}</strong></li>
         <li>Pipeline step: <strong>{pipelineState.step}</strong></li>
         <li>Users: <strong>{usernames.join(', ')}</strong></li>
       </ul>
@@ -97,7 +95,6 @@ ConsortiumResult.propTypes = {
   computation: PropTypes.object,
   complete: PropTypes.bool.isRequired,
   data: PropTypes.object,
-  history: PropTypes.array.isRequired,
   pipelineState: PropTypes.object.isRequired,
   pluginState: PropTypes.object.isRequired,
   usernames: PropTypes.array.isRequired,


### PR DESCRIPTION
# Problem

Coinstac is slow, this seems to get worse as computations progress
# Solution

Remove the history from being saved to the database, it's not entirely clear who is responsible for this being slow
