### PR TITLE
Update build scripts to zip, use archiver lib

### DIFF
--- a/packages/coinstac-ui/package.json
+++ b/packages/coinstac-ui/package.json
@@ -36,6 +36,7 @@
     "winston": "^2.1.1"
   },
   "devDependencies": {
+    "archiver": "^1.1.0",
     "babel-cli": "^6.9.0",
     "babel-core": "^6.9.1",
     "babel-loader": "^6.2.4",
@@ -68,7 +69,6 @@
     "stack-chain": "^1.3.7",
     "style-loader": "^0.13.1",
     "tape": "^4.2.0",
-    "tar.gz": "^1.0.5",
     "trace": "^2.3.3",
     "url-loader": "^0.5.6",
     "webpack": "1.13.1",

--- a/packages/coinstac-ui/scripts/build.js
+++ b/packages/coinstac-ui/scripts/build.js
@@ -5,6 +5,10 @@ const fs = require('fs');
 const os = require('os');
 const buildNative = require('./utils/build-native.js');
 
+const outputDir = `${__dirname}/../coinstac-${os.platform()}-${os.arch()}`;
+const zip = os.platform() === 'win32' ?
+  archiver.create('zip') : archiver.create('tar', { gzip: true });
+const zipOutput = os.platform() === 'win32' ? `${outputDir}.zip` : `${outputDir}.tar.gz`;
 const options = {
   asar: true,
   dir: `${__dirname}/../`,
@@ -22,26 +26,18 @@ buildNative()
   return packager(options);
 })
 .then((appPath) => {
-  let zip;
-  const dir = `${__dirname}/../coinstac-${os.platform()}-${os.arch()}`;
-
   console.log(`Finished building at: ${appPath}`); // eslint-disable-line no-console
   console.log('Now archiving...'); // eslint-disable-line no-console
 
-  if (os.platform() === 'win32') {
-    zip = archiver.create('zip');
-  } else {
-    zip = archiver.create('tar', { gzip: true });
-  }
-  const write = fs.createWriteStream(os.platform() === 'win32' ? `${dir}.zip` : `${dir}.tar.gz`);
+  const write = fs.createWriteStream(zipOutput);
 
   zip.pipe(write);
   zip.on('error', (err) => {
     throw err;
   });
-  zip.directory(dir);
+  zip.directory(outputDir);
   write.on('close', () => {
-    console.log(`Finished zipping ${dir}`); // eslint-disable-line no-console
+    console.log(`Finished zipping ${outputDir}`); // eslint-disable-line no-console
   });
 })
 .catch(err => {


### PR DESCRIPTION
# Problem
tar.gz archives are a bit more difficult for windows users to unpack

# Solution
Zipit if its windows :-)