### PR TITLE
fix logging issues as well as zipping issues

### DIFF
--- a/packages/coinstac-ui/app/common/utils/log-unhandled-error.js
+++ b/packages/coinstac-ui/app/common/utils/log-unhandled-error.js
@@ -13,7 +13,7 @@ const logLocations = {
   freebsd: '.config/coinstac/',
   linux: '.config/coinstac/',
   sunos: '.config/coinstac/',
-  win32: 'AppData/Roaming/coinstac/',
+  win32: 'coinstac/',
 };
 
 /**

--- a/packages/coinstac-ui/app/config.js
+++ b/packages/coinstac-ui/app/config.js
@@ -33,7 +33,7 @@ const conf = convict({
     noURLPrefix: true,
   },
   logFile: 'coinstac-log.json',
-  // these are appended to the home dir for you OS 
+  // these are appended to the home dir for you OS
   // *nix: ~/.config/coinstac
   // win: C:\Users\username\AppData\Local\Temp\coinstac
   logLocations: {

--- a/packages/coinstac-ui/app/config.js
+++ b/packages/coinstac-ui/app/config.js
@@ -33,12 +33,15 @@ const conf = convict({
     noURLPrefix: true,
   },
   logFile: 'coinstac-log.json',
+  // these are appended to the home dir for you OS 
+  // *nix: ~/.config/coinstac
+  // win: C:\Users\username\AppData\Local\Temp\coinstac
   logLocations: {
-    darwin: '~/Library/Logs/coinstac/',
-    freebsd: '~/.config/coinstac/',
-    linux: '~/.config/coinstac/',
-    sunos: '~/.config/coinstac/',
-    win32: '$HOME/AppData/Roaming/coinstac/',
+    darwin: 'Library/Logs/coinstac/',
+    freebsd: '.config/coinstac/',
+    linux: '.config/coinstac/',
+    sunos: '.config/coinstac/',
+    win32: 'coinstac/',
   },
 });
 

--- a/packages/coinstac-ui/app/main/utils/boot/configure-logger.js
+++ b/packages/coinstac-ui/app/main/utils/boot/configure-logger.js
@@ -7,12 +7,11 @@ const winston = require('winston');
 const promisify = require('bluebird').promisify;
 const mkdirp = promisify(require('mkdirp'));
 
-const resolveHome = (filepath) => {
-  return filepath.replace(/~|\$HOME/, process.env.HOME);
-};
-
 module.exports = function configureLogger() {
-  const logLocation = resolveHome(app.config.get('logLocations')[process.platform]);
+  const logLocation = path.join(
+    process.env.HOME || process.env.TEMP,
+    app.config.get('logLocations')[process.platform]
+    );
 
   return mkdirp(logLocation, parseInt('0775', 8))
   .then(() => {

--- a/packages/coinstac-ui/scripts/build.js
+++ b/packages/coinstac-ui/scripts/build.js
@@ -5,7 +5,8 @@ const fs = require('fs');
 const os = require('os');
 const buildNative = require('./utils/build-native.js');
 
-const outputDir = `${__dirname}/../coinstac-${os.platform()}-${os.arch()}`;
+const dirName = `coinstac-${os.platform()}-${os.arch()}`
+const outputDir = `${__dirname}/../${dirName}`;
 const zip = os.platform() === 'win32' ?
   archiver.create('zip') : archiver.create('tar', { gzip: true });
 const zipOutput = os.platform() === 'win32' ? `${outputDir}.zip` : `${outputDir}.tar.gz`;
@@ -35,7 +36,9 @@ buildNative()
   zip.on('error', (err) => {
     throw err;
   });
-  zip.directory(outputDir);
+  zip.directory(outputDir, dirName)
+  .finalize();
+  
   write.on('close', () => {
     console.log(`Finished zipping ${outputDir}`); // eslint-disable-line no-console
   });

--- a/packages/coinstac-ui/scripts/build.js
+++ b/packages/coinstac-ui/scripts/build.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const os = require('os');
 const buildNative = require('./utils/build-native.js');
 
-const dirName = `coinstac-${os.platform()}-${os.arch()}`
+const dirName = `coinstac-${os.platform()}-${os.arch()}`;
 const outputDir = `${__dirname}/../${dirName}`;
 const zip = os.platform() === 'win32' ?
   archiver.create('zip') : archiver.create('tar', { gzip: true });
@@ -38,7 +38,7 @@ buildNative()
   });
   zip.directory(outputDir, dirName)
   .finalize();
-  
+
   write.on('close', () => {
     console.log(`Finished zipping ${outputDir}`); // eslint-disable-line no-console
   });


### PR DESCRIPTION
# Problem
Errors are not being logged to the correct locations and zip files are not valid.

# Solution
Change log location format to always append to the OS specific home directories in both locations where logging happens. Zips were not being passed the correct options as well as the `finalize` method needed to be called.

Closes #94 