### PR TITLE
Feature/common tidy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 <img src="https://raw.githubusercontent.com/MRN-Code/coinstac/master/img/coinstac.png" height="75px">
 
+[ ![Codeship Status for MRN-Code/coinstac](https://app.codeship.com/projects/9a9dd9b0-8f5a-0134-c5bf-0e20509a962c/status?branch=master)](https://app.codeship.com/projects/185577)
+
 _Collaborative Informatics and Neuroimaging Suite Toolkit for Anonymous Computation, User Interface._ A research project by your friends [The Mind Research Network](http://www.mrn.org/).
 
 COINSTAC is software to foster collaborative research, removing large barriers to traditional data-centric collaboration approaches.  It enables groups of users to run common analyses _on their own machines_ over _their own datasets_ with ease.  The results of these analyses are synchronized to the cloud, and undergo aggregate analyses processes using all contributor data.  Decentralized pipelines allow for distributed, iterative, and feature rich analyses to be run, opening new and exciting capabilities for collaborative computation.  If also offers data anonymity through differential privacy algorithms, so members do not need to fear PHI traceback.
@@ -38,7 +40,7 @@ COINSTAC removes the barriers to collaborative analysis by:
 
 - **decentralizing analyses and computation**
   - each user performs analyses/pipelines/etc all on their own computers. bits and pieces of each users' output _may_ be sent to a central compute node
-  - a central compute node performs a complimentary component of the group analysis, generally a Machine Learning algorithm.  this node may trigger adjusted computations on users' machines, generally in effort to improve a model, which the research is trying to predict!  
+  - a central compute node performs a complimentary component of the group analysis, generally a Machine Learning algorithm.  this node may trigger adjusted computations on users' machines, generally in effort to improve a model, which the research is trying to predict!
 - _not_ synchronizing full datasets. instead, **synchronizing only resultant analysis metrics**
   - as previously discussed, central compute nodes aggregate these metrics, and attempt to draw conclusions from the contributor swarm
   - because machine learning algorithms can be designed to model outcomes via artifacts of your analysis Pipelines, we keep your data safely and conveniently on your own machine, _untouched_.

--- a/packages/coinstac-common/package.json
+++ b/packages/coinstac-common/package.json
@@ -23,7 +23,6 @@
     "url": "https://github.com/MRN-Code/coinstac/issues"
   },
   "dependencies": {
-    "async": "^2.0.0-rc.5",
     "bluebird": "^3.4.0",
     "coinstac-example-computation-bisect-converge": "github:mrn-code/coinstac-example-computation-bisect-converge#v2.0.2",
     "indent-string": "^3.0.0",

--- a/packages/coinstac-common/package.json
+++ b/packages/coinstac-common/package.json
@@ -26,12 +26,10 @@
     "bluebird": "^3.4.0",
     "coinstac-example-computation-bisect-converge": "github:mrn-code/coinstac-example-computation-bisect-converge#v2.0.2",
     "indent-string": "^3.0.0",
-    "joi": "^8.4.1",
+    "joi": "^10.0.0",
     "json-parse-helpfulerror": "^1.0.3",
     "laplacian-noise-ridge-regression": "github:mrn-code/decentralized-laplacian-ridge-regression#v3.1.0",
     "lodash": "^4.3.0",
-    "md5": "^2.0.0",
-    "moment": "^2.11.1",
     "pouchy": "^11.0.1"
   },
   "homepage": "http://mrn-code.github.io/coinstac#readme",

--- a/packages/coinstac-common/src/models/base.js
+++ b/packages/coinstac-common/src/models/base.js
@@ -122,6 +122,7 @@ class Base {
   }
 }
 
+Base.joi = joi;
 Base.schema = {};
 
 module.exports = Base;


### PR DESCRIPTION
# problem statements

- lots of unused deps are declared in common
- i want to use `Base` in a different project knowing the `joi` i use is the same that `joi` that common will use

# solution

- tidy deps
- expose `joi`