### PR TITLE
Update build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "swig-templates": "^2.0.1"
   },
   "scripts": {
-    "bootstrap": "lerna bootstrap",
+    "bootstrap": "echo 'Deprecated! Please use \"npm run build\"'; exit 1;",
+    "build": "lerna bootstrap",
     "build:server": "lerna bootstrap --ignore 'coinstac-{client-core,decentralized-algorithm-integration,simulator,storage-proxy,ui}'",
     "lint": "eslint '**/*.js' '**/bin/*'",
     "lintfix": "eslint --fix **/*.js",


### PR DESCRIPTION
This changes the repository build command from `npm run bootstrap` → `npm run build`. “Bootstrap” is Lerna-specific; “build“ is a better understood word for this task.