### PR TITLE
Clear covariate mapping when metadata file is removed.

### DIFF
--- a/packages/coinstac-ui/app/render/components/projects/form-project-controller.js
+++ b/packages/coinstac-ui/app/render/components/projects/form-project-controller.js
@@ -269,6 +269,8 @@ class FormProjectController extends Component {
   handleRemoveMetaFile() {
     this.setState({
       project: {
+        metaCovariateMapping: {},
+        metaFile: null,
         metaFilePath: null,
       },
     });


### PR DESCRIPTION
* **Problem:** See #101.
* **Solution:** Reset `metaCovariateMapping` and `metaFile` project state props in the metafile removal handler.
* **Testing:**
  1. Start up _coinstac-ui_
  2. Create a consortium, ensuring covariates are added
  3. Create a new project
  4. Add a metafile to the new project
  5. Map the consortium’s covariates to the metafile
  6. Remove and re-add the metafile
  7. Observe the covariate mappings are reset