### PR TITLE
Move file resolution to meta csv, disable file loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {},
   "devDependencies": {
     "async": "^2.0.0-rc.6",
-    "eslint": "^3.0.0",
+    "eslint": "^2.9.0",
     "eslint-config-airbnb": "^9.0.1",
     "eslint-plugin-import": "^1.10.1",
     "eslint-plugin-jsx-a11y": "^1.5.3",

--- a/packages/coinstac-ui/app/render/components/consortium-card.js
+++ b/packages/coinstac-ui/app/render/components/consortium-card.js
@@ -20,6 +20,7 @@ export default function ConsortiumCard(props) {
 
   let deleteButton;
   let membershipButton;
+  let editOrViewText;
 
   if (isOwner) {
     deleteButton = (
@@ -32,6 +33,7 @@ export default function ConsortiumCard(props) {
         Delete
       </Button>
     );
+    editOrViewText = 'Edit';
   } else {
     membershipButton = isMember ?
     (
@@ -54,6 +56,7 @@ export default function ConsortiumCard(props) {
         Join
       </Button>
     );
+    editOrViewText = 'View';
   }
 
   return (
@@ -86,7 +89,7 @@ export default function ConsortiumCard(props) {
                   className="glyphicon glyphicon glyphicon-eye-open"
                 ></span>
                 {' '}
-                View
+                {editOrViewText}
               </Button>
             </LinkContainer>
           </ButtonToolbar>

--- a/packages/coinstac-ui/app/render/components/consortium/consortium-form.js
+++ b/packages/coinstac-ui/app/render/components/consortium/consortium-form.js
@@ -190,9 +190,9 @@ class ConsortiumForm extends Component {
         />
         <Field
           component={ConsortiumForm.renderInput}
-          label="Description"
+          label="Public Description"
           name="description"
-          placeholder="Enter Description"
+          placeholder="Enter you description that best describes the Consortium's purpose to others"
           type="textarea"
         />
         <fieldset className="computation-select">
@@ -281,4 +281,3 @@ export default connect(mapStateToProps)(reduxForm({
   pure: false,
   validate: ConsortiumForm.validate,
 })(ConsortiumForm));
-

--- a/packages/coinstac-ui/app/render/components/projects/form-project-controller.js
+++ b/packages/coinstac-ui/app/render/components/projects/form-project-controller.js
@@ -1,5 +1,5 @@
 import app from 'ampersand-app';
-import { cloneDeep, get, noop, pickBy, values } from 'lodash';
+import { cloneDeep, get, noop, pickBy, values, tail } from 'lodash';
 import { connect } from 'react-redux';
 import React, { Component, PropTypes } from 'react';
 
@@ -41,14 +41,14 @@ class FormProjectController extends Component {
      */
     if (props.project) {
       this.state.project.consortiumId = props.project.consortiumId;
-      this.state.project.files = cloneDeep(props.project.files);
+      // TODO: enable with fileRender
+      // this.state.project.files = cloneDeep(props.project.files);
       this.state.project.metaCovariateMapping =
         cloneDeep(props.project.metaCovariateMapping);
       this.state.project.metaFile = props.project.metaFile;
       this.state.project.metaFilePath = props.project.metaFilePath;
       this.state.project.name = props.project.name;
     }
-
     this.handleAddFiles = this.handleAddFiles.bind(this);
     this.handleAddMetaFile = this.handleAddMetaFile.bind(this);
     this.handleConsortiumChange = this.handleConsortiumChange.bind(this);
@@ -81,9 +81,10 @@ class FormProjectController extends Component {
       project: 'project' in newState ?
         Object.assign({}, this.state.project, newState.project) :
         this.state.project,
-      showFilesComponent: 'showFilesComponent' in newState ?
-        newState.showFilesComponent :
-        this.state.showFilesComponent,
+      // TODO: enable with fileRender
+      // showFilesComponent: 'showFilesComponent' in newState ?
+      //   newState.showFilesComponent :
+      //   this.state.showFilesComponent,
     });
   }
 
@@ -164,8 +165,10 @@ class FormProjectController extends Component {
         this.setState({
           errors: {
             metaFile: null,
+            files: null,
           },
           project: {
+            files: [...tail(JSON.parse(metaFile)).map(metaRow => metaRow[0])],
             metaFile: JSON.parse(metaFile),
             metaFilePath,
           },
@@ -389,7 +392,8 @@ class FormProjectController extends Component {
       metaFile,
       metaFilePath,
       project,
-      showFilesComponent,
+      // TODO: enable with fileRender
+      // showFilesComponent,
     } = this.state;
 
     const isEditing = !!params.projectId;
@@ -412,20 +416,23 @@ class FormProjectController extends Component {
         isEditing={isEditing}
         metaFile={metaFile}
         metaFilePath={metaFilePath}
-        onAddFiles={this.handleAddFiles}
+        // TODO: enable with fileRender
+        // onAddFiles={this.handleAddFiles}
         onAddMetaFile={this.handleAddMetaFile}
         onConsortiumChange={this.handleConsortiumChange}
         onMapCovariate={this.handleMapCovariate}
         onNameChange={this.handleNameChange}
-        onRemoveAllFiles={this.handleRemoveAllFiles}
-        onRemoveFile={this.handleRemoveFile}
+        // TODO: enable with fileRender
+        // onRemoveAllFiles={this.handleRemoveAllFiles}
+        // onRemoveFile={this.handleRemoveFile}
         onRemoveMetaFile={this.handleRemoveMetaFile}
         onReset={this.handleReset}
         onRunComputation={this.handleRunComputation}
         onSubmit={this.handleSubmit}
         project={project}
         showComputationRunButton={showComputationRunButton}
-        showFilesComponent={showFilesComponent}
+        // TODO: enable with fileRender
+        // showFilesComponent={showFilesComponent}
       />
     );
   }

--- a/packages/coinstac-ui/app/render/components/projects/form-project-controller.js
+++ b/packages/coinstac-ui/app/render/components/projects/form-project-controller.js
@@ -6,6 +6,7 @@ import React, { Component, PropTypes } from 'react';
 import { runComputation } from '../../state/ducks/bg-services';
 import { addProject } from '../../state/ducks/projects';
 import FormProject from './form-project';
+import path from 'path';
 
 class FormProjectController extends Component {
   constructor(props) {
@@ -123,8 +124,9 @@ class FormProjectController extends Component {
         ) {
           memo[key] = 'Missing covariate mapping';
         }
-      } else if ((key === 'files' && !value.length) || !value) {
-        memo[key] = FormProjectController.ERRORS.get(key);
+      // TODO: enable with fileRender
+      // } else if (key === 'files' && !value.length) || !value) {
+      //   memo[key] = FormProjectController.ERRORS.get(key);
       } else {
         memo[key] = null;
       }
@@ -168,7 +170,10 @@ class FormProjectController extends Component {
             files: null,
           },
           project: {
-            files: [...tail(JSON.parse(metaFile)).map(metaRow => metaRow[0])],
+            files: [...tail(JSON.parse(metaFile)).map(metaRow => {
+              return path.isAbsolute(metaRow[0]) ?
+              metaRow[0] : path.resolve(path.join(path.dirname(metaFilePath), metaRow[0]));
+            })],
             metaFile: JSON.parse(metaFile),
             metaFilePath,
           },
@@ -297,6 +302,7 @@ class FormProjectController extends Component {
     const { dispatch, params: { projectId } } = this.props;
     const { router } = this.context;
     const { errors, project } = this.state;
+
     const toAdd = projectId ?
       Object.assign({}, this.props.project, project) :
       project;
@@ -309,9 +315,11 @@ class FormProjectController extends Component {
       // Ensure no errors before submitting
       dispatch(addProject(toAdd))
         .then(() => {
+
           router.push('/projects');
         })
         .catch((err) => {
+
           app.notify('error', err.message);
         });
     } else {

--- a/packages/coinstac-ui/app/render/components/projects/form-project-controller.js
+++ b/packages/coinstac-ui/app/render/components/projects/form-project-controller.js
@@ -315,11 +315,9 @@ class FormProjectController extends Component {
       // Ensure no errors before submitting
       dispatch(addProject(toAdd))
         .then(() => {
-
           router.push('/projects');
         })
         .catch((err) => {
-
           app.notify('error', err.message);
         });
     } else {
@@ -459,7 +457,7 @@ FormProjectController.ERRORS = new Map([
   ['consortiumId', 'Select a consortium'],
   ['files', 'Add some files'],
   ['metaFile', 'Trouble mapping covariates'],
-  ['metaFilePath', 'Add a meta file'],
+  ['metaFilePath', 'Add a metadata file'],
   ['name', 'Add a name'],
 ]);
 

--- a/packages/coinstac-ui/app/render/components/projects/form-project.js
+++ b/packages/coinstac-ui/app/render/components/projects/form-project.js
@@ -5,7 +5,8 @@ import {
   FormControl,
   FormGroup,
   HelpBlock,
-  Label,
+// TODO: enable with fileRender
+//  Label,
 } from 'react-bootstrap';
 import React, { Component, PropTypes } from 'react';
 
@@ -81,111 +82,112 @@ export default class FormProject extends Component {
     );
   }
 
-  renderFilesField() {
-    const {
-      errors: { files: filesError },
-      onAddFiles,
-      onRemoveAllFiles,
-      onRemoveFile,
-      project: { files },
-      showFilesComponent,
-    } = this.props;
-    let buttons;
-    let content;
-    let heading;
-    let helpBlock;
-
-    if (files.length) {
-      buttons = (
-        <div className="pull-right">
-          <Button
-            bsSize="small"
-            bsStyle="danger"
-            onClick={onRemoveAllFiles}
-            type="button"
-          >
-            <span aria-hidden="true" className="glyphicon glyphicon-minus"></span>
-            {' '}
-            Remove All Files
-          </Button>
-          {' '}
-          <Button
-            bsSize="small"
-            bsStyle="primary"
-            onClick={onAddFiles}
-            type="button"
-          >
-            <span aria-hidden="true" className="glyphicon glyphicon-plus"></span>
-            {' '}
-            Add Files
-          </Button>
-        </div>
-      );
-      content = (
-        <ul className="list-unstyled">
-          {files.map((file, index) => {
-            return (
-              <li key={index}>
-                <ProjectFile
-                  filename={file.filename}
-                  onRemove={() => onRemoveFile(file)}
-                />
-              </li>
-            );
-          })}
-        </ul>
-      );
-      heading = (
-        <span>
-          Files
-          {' '}
-          <Label>{files.length}</Label>
-        </span>
-      );
-    } else {
-      buttons = (
-        <Button
-          bsSize="small"
-          bsStyle="primary"
-          className="pull-right"
-          onClick={onAddFiles}
-          type="button"
-        >
-          <span aria-hidden="true" className="glyphicon glyphicon-plus"></span>
-          {' '}
-          Add Files
-        </Button>
-      );
-      heading = 'Files';
-
-      if (!filesError) {
-        content = (
-          <Alert bsStyle="info">Select files for the computation.</Alert>
-        );
-      }
-    }
-
-    if (!showFilesComponent) {
-      return;
-    }
-
-    if (filesError) {
-      helpBlock = <Alert bsStyle="danger">{filesError}</Alert>;
-    }
-
-    return (
-      <div className="project-form-section project-form-files">
-        <div className="project-form-section-header clearfix">
-          <h2 className="h3 pull-left">{heading}</h2>
-          {buttons}
-        </div>
-        <div className="project-form-section-content">
-          {helpBlock}
-          {content}
-        </div>
-      </div>
-    );
-  }
+  // TODO: enable with better file traversing
+  // renderFilesField() {
+  //   const {
+  //     errors: { files: filesError },
+  //     onAddFiles,
+  //     onRemoveAllFiles,
+  //     onRemoveFile,
+  //     project: { files },
+  //     showFilesComponent,
+  //   } = this.props;
+  //   let buttons;
+  //   let content;
+  //   let heading;
+  //   let helpBlock;
+  //
+  //   if (files.length) {
+  //     buttons = (
+  //       <div className="pull-right">
+  //         <Button
+  //           bsSize="small"
+  //           bsStyle="danger"
+  //           onClick={onRemoveAllFiles}
+  //           type="button"
+  //         >
+  //           <span aria-hidden="true" className="glyphicon glyphicon-minus"></span>
+  //           {' '}
+  //           Remove All Files
+  //         </Button>
+  //         {' '}
+  //         <Button
+  //           bsSize="small"
+  //           bsStyle="primary"
+  //           onClick={onAddFiles}
+  //           type="button"
+  //         >
+  //           <span aria-hidden="true" className="glyphicon glyphicon-plus"></span>
+  //           {' '}
+  //           Add Files
+  //         </Button>
+  //       </div>
+  //     );
+  //     content = (
+  //       <ul className="list-unstyled">
+  //         {files.map((file, index) => {
+  //           return (
+  //             <li key={index}>
+  //               <ProjectFile
+  //                 filename={file.filename}
+  //                 onRemove={() => onRemoveFile(file)}
+  //               />
+  //             </li>
+  //           );
+  //         })}
+  //       </ul>
+  //     );
+  //     heading = (
+  //       <span>
+  //         Files
+  //         {' '}
+  //         <Label>{files.length}</Label>
+  //       </span>
+  //     );
+  //   } else {
+  //     buttons = (
+  //       <Button
+  //         bsSize="small"
+  //         bsStyle="primary"
+  //         className="pull-right"
+  //         onClick={onAddFiles}
+  //         type="button"
+  //       >
+  //         <span aria-hidden="true" className="glyphicon glyphicon-plus"></span>
+  //         {' '}
+  //         Add Files
+  //       </Button>
+  //     );
+  //     heading = 'Files';
+  //
+  //     if (!filesError) {
+  //       content = (
+  //         <Alert bsStyle="info">Select files for the computation.</Alert>
+  //       );
+  //     }
+  //   }
+  //
+  //   if (!showFilesComponent) {
+  //     return;
+  //   }
+  //
+  //   if (filesError) {
+  //     helpBlock = <Alert bsStyle="danger">{filesError}</Alert>;
+  //   }
+  //
+  //   return (
+  //     <div className="project-form-section project-form-files">
+  //       <div className="project-form-section-header clearfix">
+  //         <h2 className="h3 pull-left">{heading}</h2>
+  //         {buttons}
+  //       </div>
+  //       <div className="project-form-section-content">
+  //         {helpBlock}
+  //         {content}
+  //       </div>
+  //     </div>
+  //   );
+  // }
 
   renderMetaFileField() {
     const {
@@ -276,7 +278,9 @@ export default class FormProject extends Component {
     return (
       <div className="project-form-section project-form-meta">
         <div className="project-form-section-header clearfix">
-          <h2 className="h3 pull-left">Meta File</h2>
+          <h3 className="h3">Meta File</h3>
+          <p>Upload a CSV with full file paths in
+          the first column and any covariates in the columns after</p>
           {button}
         </div>
         <div className="project-form-section-content">
@@ -327,8 +331,10 @@ export default class FormProject extends Component {
           {this.renderNameField()}
           {this.renderConsortiaField()}
         </div>
-
-        {this.renderFilesField()}
+        {/*
+          // TODO: enable with better file traversing
+          {this.renderFilesField()}
+        */}
         {this.renderMetaFileField()}
 
         <div className="project-form-section project-form-controls clearfix">
@@ -358,7 +364,8 @@ FormProject.propTypes = {
   consortia: PropTypes.array.isRequired,
   errors: PropTypes.shape({
     consortiumId: PropTypes.string,
-    files: PropTypes.string,
+    // TODO: enable with fileRender
+    // files: PropTypes.string,
     metaCovariateMapping: PropTypes.array,
     metaFile: PropTypes.string,
     metaFilePath: PropTypes.string,
@@ -366,30 +373,34 @@ FormProject.propTypes = {
   }),
   inputs: PropTypes.arrayOf(PropTypes.object),
   isEditing: PropTypes.bool.isRequired,
-  onAddFiles: PropTypes.func.isRequired,
+  // TODO: enable with fileRender
+  // onAddFiles: PropTypes.func.isRequired,
   onAddMetaFile: PropTypes.func.isRequired,
   onConsortiumChange: PropTypes.func.isRequired,
   onMapCovariate: PropTypes.func.isRequired,
   onNameChange: PropTypes.func.isRequired,
-  onRemoveAllFiles: PropTypes.func.isRequired,
-  onRemoveFile: PropTypes.func.isRequired,
+  // TODO: enable with fileRender
+  // onRemoveAllFiles: PropTypes.func.isRequired,
+  // onRemoveFile: PropTypes.func.isRequired,
   onRemoveMetaFile: PropTypes.func.isRequired,
   onReset: PropTypes.func.isRequired,
   onRunComputation: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
   project: PropTypes.shape({
     consortiumId: PropTypes.string,
-    files: PropTypes.arrayOf(
-      PropTypes.shape({
-        filename: PropTypes.string.isRequired,
-        tags: PropTypes.object.isRequired,
-      })
-    ).isRequired,
+    // TODO: enable with fileRender
+    // files: PropTypes.arrayOf(
+    //   PropTypes.shape({
+    //     filename: PropTypes.string.isRequired,
+    //     tags: PropTypes.object.isRequired,
+    //   })
+    // ).isRequired,
     metaCovariateMapping: PropTypes.object.isRequired,
     metaFile: PropTypes.arrayOf(PropTypes.array),
     metaFilePath: PropTypes.string,
     name: PropTypes.string.isRequired,
   }).isRequired,
   showComputationRunButton: PropTypes.bool.isRequired,
-  showFilesComponent: PropTypes.bool.isRequired,
+  // TODO: enable with fileRender
+  // showFilesComponent: PropTypes.bool.isRequired,
 };

--- a/packages/coinstac-ui/app/render/components/projects/form-project.js
+++ b/packages/coinstac-ui/app/render/components/projects/form-project.js
@@ -278,8 +278,8 @@ export default class FormProject extends Component {
     return (
       <div className="project-form-section project-form-meta">
         <div className="project-form-section-header clearfix">
-          <h3 className="h3">Meta File</h3>
-          <p>Upload a CSV with full file paths in
+          <h3 className="h3">Metadata File</h3>
+          <p>Upload a CSV with the full file paths to your data files in
           the first column and any covariates in the columns after</p>
           {button}
         </div>

--- a/packages/coinstac-ui/app/render/components/projects/project-covariates-mapper.js
+++ b/packages/coinstac-ui/app/render/components/projects/project-covariates-mapper.js
@@ -100,7 +100,7 @@ export default class ProjectCovariatesMapper extends Component {
 
     return (
       <div className="project-covariates-mapper">
-        <p>Map your meta file’s columns to required computation inputs:</p>
+        <p>Map your metadata file’s columns to the required computation input fields:</p>
         <Table striped condensed className="project-covariates-mapper">
           <thead>
             {this.renderHeadingRow()}


### PR DESCRIPTION
Moves the data file loading responsibility to the first column of the
metadata CSV for demo simplification, due to the need for more
generalization in file paths.

See #118 
See #105
Closes #103
Closes #111