### PR TITLE
User-setting lambda

### DIFF
--- a/packages/coinstac-ui/app/render/components/computation-field-basic.js
+++ b/packages/coinstac-ui/app/render/components/computation-field-basic.js
@@ -16,10 +16,17 @@ export default class ComputationFieldBasic extends Component {
   }
 
   handleButtonClick(increment) {
+    const { max, min, onChange } = this.props;
     const value = this.refs[INPUT_REF].props.value + increment;
-    this.props.onChange({
-      target: { value },
-    });
+
+    if (
+      (typeof max !== 'number' || value <= max) &&
+      (typeof min !== 'number' || value >= min)
+    ) {
+      onChange({
+        target: { value },
+      });
+    }
   }
 
   render() {
@@ -28,8 +35,11 @@ export default class ComputationFieldBasic extends Component {
       fieldIndex,
       help,
       label,
+      max,
+      min,
       onChange,
       options,
+      step,
       type,
       value,
     } = this.props;
@@ -59,10 +69,21 @@ export default class ComputationFieldBasic extends Component {
         </FormControl>
       );
     } else if (type === 'number') {
+      const localStep = step || 1;
+
+      controlProps.step = localStep;
       controlProps.type = 'number';
       formGroupProps.className = 'computation-field-number';
 
-      if (value) {
+      if (max) {
+        controlProps.max = max;
+      }
+
+      if (min) {
+        controlProps.min = min;
+      }
+
+      if (typeof value !== 'number' || typeof value !== 'string') {
         controlProps.value = value;
       }
 
@@ -71,7 +92,7 @@ export default class ComputationFieldBasic extends Component {
           <Button
             aria-label="Subtract 1"
             bsStyle="primary"
-            onClick={() => this.handleButtonClick(-1)}
+            onClick={() => this.handleButtonClick(-1 * localStep)}
           >
             <span className="glyphicon glyphicon-minus"></span>
           </Button>
@@ -79,7 +100,7 @@ export default class ComputationFieldBasic extends Component {
           <Button
             aria-label="Add 1"
             bsStyle="primary"
-            onClick={() => this.handleButtonClick(1)}
+            onClick={() => this.handleButtonClick(localStep)}
           >
             <span className="glyphicon glyphicon-plus"></span>
           </Button>
@@ -102,8 +123,11 @@ ComputationFieldBasic.propTypes = {
   fieldIndex: PropTypes.number.isRequired,
   help: PropTypes.string,
   label: PropTypes.string.isRequired,
+  max: PropTypes.number,
+  min: PropTypes.number,
   onChange: PropTypes.func.isRequired,
   options: PropTypes.array,
+  step: PropTypes.number,
   type: PropTypes.string.isRequired,
   value: PropTypes.oneOfType([
     PropTypes.array,

--- a/packages/coinstac-ui/app/render/components/computation-field-basic.js
+++ b/packages/coinstac-ui/app/render/components/computation-field-basic.js
@@ -17,14 +17,20 @@ export default class ComputationFieldBasic extends Component {
 
   handleButtonClick(increment) {
     const { max, min, onChange } = this.props;
-    const value = this.refs[INPUT_REF].props.value + increment;
+    const value = this.refs[INPUT_REF].props.value;
 
-    if (
+    if (typeof value !== 'number' || Number.isNaN(value)) {
+      throw new Error('No value!');
+    } else if (
       (typeof max !== 'number' || value <= max) &&
       (typeof min !== 'number' || value >= min)
     ) {
+      const newValue = value + increment;
+
       onChange({
-        target: { value },
+        target: {
+          value: newValue.toString(),
+        },
       });
     }
   }

--- a/packages/coinstac-ui/app/render/components/consortium/consortium-computation-fields.js
+++ b/packages/coinstac-ui/app/render/components/consortium/consortium-computation-fields.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import ComputationFieldBasic from '../computation-field-basic';
 import ComputationFieldCovariates from '../computation-field-covariates';
+import { round } from 'lodash';
 
 export default function ConsortiumComputationFields(props) {
   const {
@@ -13,7 +14,18 @@ export default function ConsortiumComputationFields(props) {
   return (
     <ol className="list-unstyled">
       {fields.map(
-        ({ help, label, type, values }, fieldIndex) => {
+        (
+          {
+            help,
+            label,
+            max,
+            min,
+            step,
+            type,
+            values,
+          },
+          fieldIndex
+        ) => {
           const fieldProps = {
             disabled: !isOwner,
             fieldIndex,
@@ -36,7 +48,6 @@ export default function ConsortiumComputationFields(props) {
              */
             fieldProps.onChange = (changeValue, itemsIndex) => {
               let value = activeComputationInputs[fieldIndex] || [];
-              // debugger;
               if (!changeValue) {
                 value = value.filter((v, i) => i !== itemsIndex);
               } else if (itemsIndex > value.length - 1) {
@@ -57,12 +68,16 @@ export default function ConsortiumComputationFields(props) {
             computationField = <ComputationFieldCovariates {...fieldProps} />;
           } else {
             if (type === 'number') {
-              fieldProps.onChange = event => {
-                updateComputationField(
-                  fieldIndex,
-                  parseInt(event.target.value, 10)
-                );
+              fieldProps.onChange = ({ target: { value } }) => {
+                const newValue = typeof value === 'string' ?
+                  parseFloat(value, 10) :
+                  value;
+
+                updateComputationField(fieldIndex, round(newValue, 3));
               };
+              fieldProps.max = max;
+              fieldProps.min = min;
+              fieldProps.step = step;
 
               if (typeof activeComputationInputs[fieldIndex] !== 'undefined') {
                 fieldProps.value = activeComputationInputs[fieldIndex];

--- a/packages/coinstac-ui/app/render/components/consortium/consortium-computation-fields.js
+++ b/packages/coinstac-ui/app/render/components/consortium/consortium-computation-fields.js
@@ -47,7 +47,10 @@ export default function ConsortiumComputationFields(props) {
              * @param {number} itemsIndex
              */
             fieldProps.onChange = (changeValue, itemsIndex) => {
-              let value = activeComputationInputs[fieldIndex] || [];
+              let value = Array.isArray(activeComputationInputs[fieldIndex]) ?
+                activeComputationInputs[fieldIndex] :
+                [];
+
               if (!changeValue) {
                 value = value.filter((v, i) => i !== itemsIndex);
               } else if (itemsIndex > value.length - 1) {

--- a/packages/coinstac-ui/app/render/components/consortium/consortium-result-meta.js
+++ b/packages/coinstac-ui/app/render/components/consortium/consortium-result-meta.js
@@ -11,7 +11,7 @@ export default function ConsortiumResultMeta({
 
   // TODO: Don't hard-code for inputs
   if (computation.name === 'decentralized-single-shot-ridge-regression') {
-    covariates = computationInputs[0][1].map(x => x.name);
+    covariates = computationInputs[0][2].map(x => x.name);
   } else {
     const maxIterations = computationInputs[0][1];
 
@@ -21,7 +21,7 @@ export default function ConsortiumResultMeta({
      */
     const currentIteration = step > maxIterations ? maxIterations : step;
 
-    covariates = computationInputs[0][2].map(x => x.name);
+    covariates = computationInputs[0][3].map(x => x.name);
     iterations = (
       <li>
         <strong>Iterations:</strong>

--- a/packages/coinstac-ui/app/render/components/consortium/consortium-result-meta.js
+++ b/packages/coinstac-ui/app/render/components/consortium/consortium-result-meta.js
@@ -8,10 +8,12 @@ export default function ConsortiumResultMeta({
 }) {
   let covariates;
   let iterations;
+  let lambda;
 
   // TODO: Don't hard-code for inputs
   if (computation.name === 'decentralized-single-shot-ridge-regression') {
     covariates = computationInputs[0][2].map(x => x.name);
+    lambda = computationInputs[0][1];
   } else {
     const maxIterations = computationInputs[0][1];
 
@@ -29,6 +31,7 @@ export default function ConsortiumResultMeta({
         <span className="text-muted">/{maxIterations}</span>
       </li>
     );
+    lambda = computationInputs[0][2];
   }
 
   return (
@@ -47,6 +50,7 @@ export default function ConsortiumResultMeta({
         {' '}
         {computationInputs[0][0].join(', ')}
       </li>
+      <li><strong>Lambda:</strong>{' '}<samp>{lambda}</samp></li>
       <li><strong>Users:</strong>{` ${usernames.join(', ')}`}</li>
     </ul>
   );

--- a/packages/coinstac-ui/app/render/components/consortium/consortium-result.js
+++ b/packages/coinstac-ui/app/render/components/consortium/consortium-result.js
@@ -63,8 +63,8 @@ export default function ConsortiumResult({
      */
     const covariates =
       computation.name === 'decentralized-single-shot-ridge-regression' ?
-      computationInputs[0][1].map(x => x.name) :
-      computationInputs[0][2].map(x => x.name);
+      computationInputs[0][2].map(x => x.name) :
+      computationInputs[0][3].map(x => x.name);
 
     dataOutput = (
       <div>


### PR DESCRIPTION
### Problem

Consortium owners can't set “lambda” in computation runs (see #76).

### Solution

* Extend the `number` input type to support `step`, `min` and `max` properties:

  ```js
  {
    defaultValue: 1,
    label: 'Lambda',
    max: 1,
    min: 0,
    step: 0.05,
    type: 'number',
  }
  ```
* Modify `number` input-related code to accept non-integer numbers
* Fix a bug where `number` inputs with a `0` value cause redux-form to mark the elements as non-controlled.

### Testing

1. Check out _feature/#76-lambda-input_.
2. Ensure [MRN-Code/decentralized-laplacian-ridge-regression](https://github.com/MRN-Code/decentralized-laplacian-ridge-regression) and [MRN-Code/decentralized-single-shot-ridge-regression](https://github.com/MRN-Code/decentralized-single-shot-ridge-regression) are set up and the _feature/lambda-input_ branch is checked out.
3. Link computations in _packages/coinstac-computation-registry_:

    ```shell
    cd packages/coinstac-computation-registry
    npm link laplacian-noise-ridge-regression
    npm link decentralized-single-shot-ridge-regression
    ```
    (Note their _package.json_ names don’t match their repository names.)
4. Run computations:
    * Run FreeSurfer single-shot with a custom lambda
    * Run FreeSurfer multi-shot with a custom lambda
5. Ensure custom lambda values show up in results UI

### Todo

- [x] Merge MRN-Code/decentralized-laplacian-ridge-regression#12
- [x] Merge MRN-Code/decentralized-single-shot-ridge-regression#12
- [x] Publish both computations
- [x] Bump computation versions in _coinstac-computation-registry_