### PR TITLE
Inter-process error notification

### DIFF
--- a/packages/coinstac-client-core/test/sub-api/project-service.js
+++ b/packages/coinstac-client-core/test/sub-api/project-service.js
@@ -129,6 +129,8 @@ test('ProjectService#setMetaContents errors', t => {
     ['./M102.txt', '28', 'true'],
   ];
   const metaFilePath = path.join(__dirname, 'metadata.csv');
+  const statAllStub = sinon.stub(ProjectService, 'statAll')
+    .returns(Promise.resolve());
 
   project.get.returns(Promise.resolve({
     _id: projectId,
@@ -221,7 +223,8 @@ test('ProjectService#setMetaContents errors', t => {
         'errors with bad metaFile column'
       );
     })
-    .catch(t.end);
+    .catch(t.end)
+    .then(statAllStub.restore, statAllStub.restore);
 });
 
 test('ProjectService - setMetaContents', t => {
@@ -303,6 +306,9 @@ test('ProjectService - setMetaContents', t => {
     project
   );
 
+  const statAllStub = sinon.stub(ProjectService, 'statAll')
+    .returns(Promise.resolve());
+
   t.plan(3);
 
   setMetaContents(projectId)
@@ -341,7 +347,8 @@ test('ProjectService - setMetaContents', t => {
         'adds tags to project\'s files'
       );
     })
-    .catch(t.end);
+    .catch(t.end)
+    .then(statAllStub.restore, statAllStub.restore);
 });
 
 // TODO: This test fails when this file is tested independently. Why?
@@ -654,4 +661,44 @@ test('ProjectService - database listener events', t => {
       // teardown
       dbListenerStub.restore();
     });
+});
+
+
+test('ProjectService - stat all files', (t) => {
+  const badFiles = ['/such/a/nasty/file.txt', '/incredible/stamina.csv'];
+  const goodFiles = ['/path/to/rando.txt', 'where/am/i/even.csv'];
+  const statStub = sinon.stub(fs, 'stat');
+
+  statStub.onCall(0).yields({
+    code: 'ENOENT',
+  });
+  statStub.onCall(1).yields({
+    code: 'ENOENT',
+  });
+  statStub.yields(null, {});
+
+  t.plan(3);
+
+  ProjectService.statAll(badFiles, __dirname)
+    .then(() => t.fail('Resolves with bad file paths'))
+    .catch((error) => {
+      t.ok(
+        badFiles.every(f => statStub.calledWith(f)),
+        'stats every file'
+      );
+      t.ok(
+        badFiles.every(f => error.message.includes(f)),
+        'adds bad files to error message'
+      );
+
+      return ProjectService.statAll(goodFiles, __dirname);
+    })
+    .then(() => {
+      t.ok(
+        statStub.calledWith(path.resolve(__dirname, goodFiles[1])),
+        'resolves non-absolute file paths'
+      );
+    })
+    .catch(t.end)
+    .then(statStub.restore, statStub.restore);
 });

--- a/packages/coinstac-ui/app/main/utils/boot/configure-unhandled-rejections.js
+++ b/packages/coinstac-ui/app/main/utils/boot/configure-unhandled-rejections.js
@@ -15,4 +15,5 @@ const app = require('ampersand-app');
 
 process.on('unhandledRejection', (reason, p) => {
   app.logger.error('Unhandled rejection at: Promise ', p, ' reason: ', reason);
+  app.mainWindow.webContents.send('async-error', reason.message);
 });

--- a/packages/coinstac-ui/app/render/components/notification.js
+++ b/packages/coinstac-ui/app/render/components/notification.js
@@ -1,8 +1,20 @@
 import NotificationSystem from 'react-notification-system';
 import React from 'react';
 import app from 'ampersand-app';
+import { ipcRenderer } from 'electron';
+import truncate from 'lodash/truncate';
+
 
 export default class Notify extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.handleAsyncError = this.handleAsyncError.bind(this);
+  }
+
+  componentWillMount() {
+    ipcRenderer.on('async-error', this.handleAsyncError);
+  }
 
   /**
    * build the notification system _once_, and enforce that it is not dually instantiated.
@@ -16,6 +28,19 @@ export default class Notify extends React.Component {
     }
     app.notifications = this;
     app.notify = (level, message) => this.push({ level, message, autoDismiss: 2 });
+  }
+
+
+  componentWillUnmount() {
+    ipcRenderer.removeListener('async-error', this.handleAsyncError);
+  }
+
+  handleAsyncError(event, message) {
+    this.push({
+      autoDismiss: 0,
+      level: 'error',
+      message: truncate(message, { length: 250 }),
+    });
   }
 
   /**


### PR DESCRIPTION
* **Problems:**
  * Main process errors don't always cause UI notifications
  * Projects with non-existent files :boom: explode in a non-useful way
* **Solutions:**
  * Add IPC event for async errors and wire up to UI error notification
  * `fs.stat` project’s files, throw a useful error when files DNE
* **Testing:**
  1. Spin up fresh client
  2. Create a project with a CSV from the _test_data_complete_ set.
  3. Try to run project
  4. Observe “Project files don't exist” error in UI