### PR TITLE
remove built tar first to prevent re-packing it

### DIFF
--- a/packages/coinstac-ui/scripts/build.js
+++ b/packages/coinstac-ui/scripts/build.js
@@ -2,8 +2,10 @@ const prom = require('bluebird').promisify;
 const packager = prom(require('electron-packager'));
 const archiver = require('archiver');
 const fs = require('fs');
+const rm = require('rimraf');
 const os = require('os');
 const buildNative = require('./utils/build-native.js');
+const bb = require('bluebird');
 
 const dirName = `coinstac-${os.platform()}-${os.arch()}`;
 const outputDir = `${__dirname}/../${dirName}`;
@@ -20,7 +22,8 @@ const options = {
 };
 
 // TODO: build mult arch when possible
-buildNative()
+bb.promisify(rm)(zipOutput)
+.then(() => buildNative())
 .then(() => {
   options.arch = os.arch();
   options.platform = os.platform();


### PR DESCRIPTION
Builds can grow in size if you are lazy and don't delete your tar'd build ----solution: rm it
