### PR TITLE
Correct local R-squared property.

### DIFF
--- a/packages/coinstac-ui/app/render/components/consortium/consortium-result.js
+++ b/packages/coinstac-ui/app/render/components/consortium/consortium-result.js
@@ -95,7 +95,7 @@ export default function ConsortiumResult({
                 key={prop}
                 name={usernames[prop]}
                 pValue={item.pValueOriginal}
-                rSquared={item.rSquared}
+                rSquared={item.rSquaredOriginal}
                 tValue={item.tValueOriginal}
               />,
             ];


### PR DESCRIPTION
* **Problem:** Site-specific results rely on `rSquared` while the P value and T value rely on `pValueOriginal` and `tValueOriginal`
* **Solution:** Update R-squared to use `rSquaredOriginal`
* **Test:** Run e2e multi-shot and single-shot computations