### PR TITLE
Update computations for ROI alpha-sorting

### DIFF
--- a/packages/coinstac-computation-registry/package.json
+++ b/packages/coinstac-computation-registry/package.json
@@ -12,8 +12,8 @@
   ],
   "dependencies": {
     "coinstac-common": "^2.3.1",
-    "decentralized-single-shot-ridge-regression": "github:mrn-code/decentralized-single-shot-ridge-regression#v1.1.7",
-    "laplacian-noise-ridge-regression": "github:mrn-code/decentralized-laplacian-ridge-regression#v3.1.7",
+    "decentralized-single-shot-ridge-regression": "github:mrn-code/decentralized-single-shot-ridge-regression#v1.1.8",
+    "laplacian-noise-ridge-regression": "github:mrn-code/decentralized-laplacian-ridge-regression#v3.1.8",
     "lodash": "^4.17.4",
     "read-pkg-up": "^2.0.0"
   },

--- a/packages/coinstac-computation-registry/src/decentralized-computations.json
+++ b/packages/coinstac-computation-registry/src/decentralized-computations.json
@@ -1,11 +1,11 @@
 [
   {
     "name": "laplacian-noise-ridge-regression",
-    "tags": ["3.1.7"],
+    "tags": ["3.1.8"],
     "url": "https://github.com/MRN-Code/decentralized-laplacian-ridge-regression"
   }, {
     "name": "decentralized-single-shot-ridge-regression",
-    "tags": ["1.1.7"],
+    "tags": ["1.1.8"],
     "url": "https://github.com/MRN-Code/decentralized-single-shot-ridge-regression"
   }
 ]


### PR DESCRIPTION
* **Problem:** See #150.
* **Solution:** Add FreeSurfer ROI alpha-sorting in computations. Bump computations' versions in COINSTAC.
* **Testing:** Check computations' ROIs in the UI.