### PR TITLE
Clear project metadata when computation input changes

### DIFF
--- a/packages/coinstac-client-core/package.json
+++ b/packages/coinstac-client-core/package.json
@@ -41,6 +41,7 @@
     "commander": "^2.9.0",
     "convict": "^1.3.0",
     "csv-parse": "^1.1.5",
+    "deep-equal": "^1.0.1",
     "halfpenny": "^6.0.0",
     "hawk": "^3.1.0",
     "inquirer": "^1.1.0",

--- a/packages/coinstac-client-core/test/sub-api/computation-service.js
+++ b/packages/coinstac-client-core/test/sub-api/computation-service.js
@@ -139,14 +139,19 @@ tape('ComputationService :: doTriggerRunner errors', t => {
   const params = getStubbedParams();
   const computationService = new ComputationService(params);
 
-  params.client.projects.get.returns(Promise.resolve({
+  params.client.projects.setMetaContents.returns(Promise.resolve({
+    computationInputs: ['some', ['inputs']],
     files: [{
       filename: 'session-ale',
       tags: {},
     }],
   }));
 
-  t.plan(3);
+  params.client.consortia.get.returns({
+    activeComputationInputs: ['some', 'inputs'],
+  });
+
+  t.plan(4);
 
   computationService.doTriggerRunner({})
     .catch(() => {
@@ -164,6 +169,19 @@ tape('ComputationService :: doTriggerRunner errors', t => {
     })
     .catch(() => {
       t.pass('rejects without run ID');
+
+      return computationService.doTriggerRunner({
+        consortiumId: 'pilsner',
+        projectId: 'ipa',
+        runId: 'porter',
+      });
+    })
+    .catch((error) => {
+      // TODO: Export computation sub-api's errors for testing
+      t.ok(
+        error.message.includes('inputs must'),
+        'rejects with non-equal computation inputs'
+      );
     });
 });
 
@@ -174,6 +192,10 @@ tape('ComputationService :: doTriggerRunner', t => {
   const consortiumId = 'the-wildest-computation';
   const project = {
     _id: 'a-project-so-sweet',
+    computationInputs: [[
+      ['TotalGrayVol'],
+      200,
+    ]],
     name: 'The Sweetest Project',
     files: [{
       filename: '/Users/coinstac/dope-file.txt',

--- a/packages/coinstac-common/src/models/project.js
+++ b/packages/coinstac-common/src/models/project.js
@@ -17,6 +17,20 @@ class Project extends PouchDocument {}
 Project.schema = Object.assign({
   name: joi.string().min(1).regex(/[a-zA-Z]+/, 'at least one character')
     .required(),
+
+  /**
+   * A project's consortium's `activeComputationInputs` are stashed on the
+   * `computationInputs` property to ensure the user properly configures the
+   * project for the computation run. coinstac-client-core compares the
+   * consortium's computation inputs to the project's prior to run and throws
+   * when they don't match.
+   *
+   * @todo Find better method for guaranteeing project-to-computation input
+   * alignment.
+   *
+   * {@link https://github.com/MRN-Code/coinstac/issues/151}
+   */
+  computationInputs: joi.array().default([]),
   consortiumId: joi.string().optional(),
   files: joi.alternatives().try(joi.array()).default([]),
   metaFile: joi.array(),

--- a/packages/coinstac-simulator/src/local.js
+++ b/packages/coinstac-simulator/src/local.js
@@ -139,13 +139,22 @@ function boot({
       getAllDocuments(client.dbRegistry, 'consortia'),
       client.projects.getCSV(data.metaFilePath),
     ]))
-    .then(([[{ _id: consortiumId }], csv]) => {
+    .then(([
+      [
+        {
+          _id: consortiumId,
+          activeComputationInputs: computationInputs,
+        },
+      ],
+      csv,
+    ]) => {
       logger.verbose('Saving project');
 
       const metaFile = JSON.parse(csv);
 
       return client.projects.save({
         consortiumId,
+        computationInputs,
         files: client.projects.getFilesFromMetadata(
           data.metaFilePath,
           metaFile

--- a/packages/coinstac-ui/app/render/components/projects/form-project-controller.js
+++ b/packages/coinstac-ui/app/render/components/projects/form-project-controller.js
@@ -171,7 +171,7 @@ class FormProjectController extends Component {
             files: null,
           },
           project: {
-            files: app.core.projects.getFilesFromMetaData(
+            files: app.core.projects.getFilesFromMetadata(
               metaFilePath,
               metaFile
             ),
@@ -286,7 +286,7 @@ class FormProjectController extends Component {
   }
 
   handleReset() {
-    this.context.router.push('/projects');
+    this.context.router.push('/my-files');
   }
 
   handleRunComputation() {
@@ -316,7 +316,7 @@ class FormProjectController extends Component {
       // Ensure no errors before submitting
       dispatch(addProject(toAdd))
         .then(() => {
-          router.push('/projects');
+          router.push('/my-files');
         })
         .catch((err) => {
           app.notify('error', err.message);

--- a/packages/coinstac-ui/app/render/components/projects/form-project-controller.js
+++ b/packages/coinstac-ui/app/render/components/projects/form-project-controller.js
@@ -2,6 +2,7 @@ import app from 'ampersand-app';
 import { cloneDeep, get, noop, pickBy, values } from 'lodash';
 import { connect } from 'react-redux';
 import React, { Component, PropTypes } from 'react';
+import deepEqual from 'deep-equal';
 
 import { runComputation } from '../../state/ducks/bg-services';
 import { addProject } from '../../state/ducks/projects';
@@ -22,6 +23,7 @@ class FormProjectController extends Component {
         name: null,
       },
       project: {
+        computationInputs: null,
         consortiumId: undefined,
         files: [],
         // TODO: Don't tie datastructure to input type
@@ -43,11 +45,33 @@ class FormProjectController extends Component {
       this.state.project.consortiumId = props.project.consortiumId;
       // TODO: enable with fileRender
       // this.state.project.files = cloneDeep(props.project.files);
-      this.state.project.metaCovariateMapping =
-        cloneDeep(props.project.metaCovariateMapping);
       this.state.project.metaFile = props.project.metaFile;
       this.state.project.metaFilePath = props.project.metaFilePath;
       this.state.project.name = props.project.name;
+
+      if (props.project.consortiumId) {
+        const consortium = props.consortia.find(
+          ({ _id }) => _id === props.project.consortiumId
+        );
+
+        /**
+         * Always load the consortium's `activeComputationInputs` to ensure the
+         * project's `metaCovariateMapping` matches.
+         *
+         * @todo Investigate race conditions where a consortium's inputs change
+         * while a user creates a project.
+         */
+        this.state.project.computationInputs =
+          cloneDeep(consortium.activeComputationInputs);
+
+        if (deepEqual(
+          props.project.computationInputs,
+          consortium.activeComputationInputs
+        )) {
+          this.state.project.metaCovariateMapping =
+            cloneDeep(props.project.metaCovariateMapping);
+        }
+      }
     }
     this.handleAddFiles = this.handleAddFiles.bind(this);
     this.handleAddMetaFile = this.handleAddMetaFile.bind(this);
@@ -195,7 +219,13 @@ class FormProjectController extends Component {
 
     this.setState({
       errors: this.getErrors({ consortiumId }),
-      project: { consortiumId },
+      project: {
+        consortiumId,
+        computationInputs: cloneDeep(this.props.consortia
+          .find(({ _id }) => _id === consortiumId)
+          .activeComputationInputs),
+        metaCovariateMapping: {},
+      },
     });
   }
 

--- a/packages/coinstac-ui/app/render/components/projects/project-card.js
+++ b/packages/coinstac-ui/app/render/components/projects/project-card.js
@@ -7,6 +7,7 @@ export class ProjectCard extends Component {
   maybeRenderComputationRunButton() {
     const {
       allowComputationRun,
+      isInvalidMapping,
       runComputation,
       showComputationRunButton,
     } = this.props;
@@ -17,7 +18,7 @@ export class ProjectCard extends Component {
           bsSize="small"
           bsStyle="primary"
           className="pull-right"
-          disabled={!allowComputationRun}
+          disabled={isInvalidMapping || !allowComputationRun}
           onClick={runComputation}
         >
           <span
@@ -33,51 +34,56 @@ export class ProjectCard extends Component {
   }
 
   renderComputationStatus() {
-    const { computationStatus } = this.props;
-    const className = `project-status ${ProjectCard.computationStatusClassNames.get(
-      computationStatus
+    const { computationStatus, isInvalidMapping } = this.props;
+    const className = `project-status ${(
+      isInvalidMapping ?
+        ProjectCard.computationStatusClassNames.get('error') :
+        ProjectCard.computationStatusClassNames.get(computationStatus)
     )}`;
     let status;
 
-    switch (computationStatus) {
-      case 'active':
-        status = (
-          <span>
-            <span aria-hidden="true" className="glyphicon glyphicon-refresh"></span>
-            {' '}
-            Running
-          </span>
-        );
-        break;
-      case 'complete':
-        status = (
-          <span>
-            <span aria-hidden="true" className="glyphicon glyphicon-ok"></span>
-            {' '}
-            Complete
-          </span>
-        );
-        break;
-      case 'error':
-        status = (
-          <span>
-            <span aria-hidden="true" className="glyphicon glyphicon-alert"></span>
-            {' '}
-            Error
-          </span>
-        );
-        break;
-      case 'waiting':
-        status = (
-          <span>
-            <span aria-hidden="true" className="glyphicon glyphicon-alert"></span>
-            {' '}
-            Waiting to start
-          </span>
-        );
-        break;
-      default:
-        status = <span>Unknown status</span>;
+    if (isInvalidMapping) {
+      status = (
+        <span>
+          <span aria-hidden="true" className="glyphicon glyphicon-exclamation-sign"></span>
+          {' '}
+          Must remap covariates
+        </span>
+      );
+    } else if (computationStatus === 'active') {
+      status = (
+        <span>
+          <span aria-hidden="true" className="glyphicon glyphicon-refresh"></span>
+          {' '}
+          Running
+        </span>
+      );
+    } else if (computationStatus === 'complete') {
+      status = (
+        <span>
+          <span aria-hidden="true" className="glyphicon glyphicon-ok"></span>
+          {' '}
+          Complete
+        </span>
+      );
+    } else if (computationStatus === 'error') {
+      status = (
+        <span>
+          <span aria-hidden="true" className="glyphicon glyphicon-alert"></span>
+          {' '}
+          Error
+        </span>
+      );
+    } else if (computationStatus === 'waiting') {
+      status = (
+        <span>
+          <span aria-hidden="true" className="glyphicon glyphicon-alert"></span>
+          {' '}
+          Waiting to start
+        </span>
+      );
+    } else {
+      status = <span>Unknown status</span>;
     }
 
     return <div className={className}>{status}</div>;
@@ -152,6 +158,7 @@ ProjectCard.propTypes = {
     'waiting',
   ]).isRequired,
   id: PropTypes.string.isRequired,
+  isInvalidMapping: PropTypes.bool.isRequired,
   name: PropTypes.string.isRequired,
   removeProject: PropTypes.func.isRequired,
   runComputation: PropTypes.func.isRequired,

--- a/packages/coinstac-ui/app/render/components/projects/projects-list.js
+++ b/packages/coinstac-ui/app/render/components/projects/projects-list.js
@@ -11,6 +11,7 @@ import { ProjectCard } from './project-card.js';
 import { hilarious } from '../../utils/hilarious-loading-messages.js';
 import app from 'ampersand-app';
 import { runComputation } from '../../state/ducks/bg-services';
+import deepEqual from 'deep-equal';
 
 class ProjectsList extends Component {
   constructor(props) {
@@ -79,17 +80,21 @@ class ProjectsList extends Component {
           </LinkContainer>
         </div>
         <div className="projects-list">
-          {projects.map(project => {
+          {projects.map((project) => {
             const consortium = consortia.find(c => {
               return c._id === project.consortiumId;
             });
 
             let showComputationRunButton = false;
+            let isInvalidMapping = false;
 
             if (consortium) {
               showComputationRunButton =
                 consortium.owners.indexOf(username) > -1;
-              // computationState
+              isInvalidMapping = !deepEqual(
+                consortium.activeComputationInputs,
+                project.computationInputs
+              );
             }
 
             return (
@@ -97,6 +102,7 @@ class ProjectsList extends Component {
                 allowComputationRun={project.allowComputationRun}
                 computationStatus={project.status}
                 id={project._id}
+                isInvalidMapping={isInvalidMapping}
                 key={`project-card-${project._id}`}
                 name={project.name}
                 removeProject={() => this.delete(project)}
@@ -112,11 +118,16 @@ class ProjectsList extends Component {
 }
 
 ProjectsList.propTypes = {
-  consortia: PropTypes.arrayOf(PropTypes.object).isRequired,
+  consortia: PropTypes.arrayOf(PropTypes.shape({
+    _id: PropTypes.string.isRequired,
+    activeComputationInputs: PropTypes.array.isRequired,
+    owners: PropTypes.arrayOf(PropTypes.string).isRequired,
+  })).isRequired,
   dispatch: PropTypes.func.isRequired,
   projects: PropTypes.arrayOf(PropTypes.shape({
     _id: PropTypes.string,
     allowComputationRun: PropTypes.bool.isRequired,
+    computationInputs: PropTypes.array.isRequired,
     consortiumId: PropTypes.string,
     files: PropTypes.array,
     name: PropTypes.string.isRequired,

--- a/packages/coinstac-ui/package.json
+++ b/packages/coinstac-ui/package.json
@@ -15,6 +15,7 @@
     "coinstac-common": "^2.3.1",
     "commander": "^2.9.0",
     "convict": "^1.4.0",
+    "deep-equal": "^1.0.1",
     "lodash": "4.14.0",
     "md5": "^2.0.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
### Problem

See #151.

### Solution

Add a consortium’s `activeComputationInputs` to a project. Don't allow a project to run when the consortium’s and project’s computation inputs don’t match. (See liberally commented code for details.)

### Testing

#### Setup

1. Pull the branch:
    ```shell
    git fetch --all
    git checkout enhancement/#151-project-inputs
    ```
2. Install dependencies:
    ```shell
    npm run build
    ```
3. Boot COINSTAC’s UI
4. Create two consortia, ensuring each uses a different computation
5. Create a project

#### Test Cases

* A consortium’s computation inputs (ex: covariate names) change: the project should be flagged an un-runable
* An un-runable project’s CSV mapping `select`s should clear when the user edits the project
* A project’s selected consortium (from the dropdown) changes: the project’s CSV mapping `select`s should reset