### PR TITLE
Enhancement/#155 client memory dbs

### DIFF
--- a/packages/coinstac-common/src/services/classes/db-registry.js
+++ b/packages/coinstac-common/src/services/classes/db-registry.js
@@ -8,7 +8,6 @@ const assign = require('lodash/assign');
 const cloneDeep = require('lodash/cloneDeep');
 const defaultsDeep = require('lodash/defaultsDeep');
 const get = require('lodash/get');
-const set = require('lodash/set');
 const without = require('lodash/without');
 const result = require('lodash/result');
 
@@ -194,17 +193,12 @@ class DBRegistry {
      *
      * {@link https://github.com/MRN-Code/coinstac/issues/155}
      */
-    if (this.localStores && this.localStores.indexOf('projects') > -1) {
-      conf.pouchConfig.adapter = connStr.includes('projects') ?
-        'leveldb' :
-        'memory';
-    } else {
-      // convert string declared PouchDB adapter to adapter instance
-      const requestedAdapter = get(conf, 'pouchConfig.db');
-      /* istanbul ignore if */
-      if (typeof requestedAdapter === 'string') {
-        set(conf, 'pouchConfig.db', require(requestedAdapter)); // eslint-disable-line
-      }
+    if (
+      this.localStores &&
+      this.localStores.indexOf('projects') > -1 &&
+      conf.pouchConfig.getAdapter instanceof Function
+    ) {
+      conf.pouchConfig.adapter = conf.pouchConfig.getAdapter(connStr);
     }
 
     // build db and cache it

--- a/packages/coinstac-common/src/services/classes/db-registry.js
+++ b/packages/coinstac-common/src/services/classes/db-registry.js
@@ -9,7 +9,6 @@ const cloneDeep = require('lodash/cloneDeep');
 const defaultsDeep = require('lodash/defaultsDeep');
 const get = require('lodash/get');
 const set = require('lodash/set');
-const isString = require('lodash/isString');
 const without = require('lodash/without');
 const result = require('lodash/result');
 
@@ -189,11 +188,23 @@ class DBRegistry {
 
     conf.pouchConfig.ajax = result(this, 'ajax');
 
-    // convert string declared PouchDB adapter to adapter instance
-    const requestedAdapter = get(conf, 'pouchConfig.db');
-    /* istanbul ignore if */
-    if (isString(requestedAdapter)) {
-      set(conf, 'pouchConfig.db', require(requestedAdapter)); // eslint-disable-line
+    /**
+     * Ensure local (client) instances' non-projects databases are stored in
+     * memory.
+     *
+     * {@link https://github.com/MRN-Code/coinstac/issues/155}
+     */
+    if (this.localStores && this.localStores.indexOf('projects') > -1) {
+      conf.pouchConfig.adapter = connStr.includes('projects') ?
+        'leveldb' :
+        'memory';
+    } else {
+      // convert string declared PouchDB adapter to adapter instance
+      const requestedAdapter = get(conf, 'pouchConfig.db');
+      /* istanbul ignore if */
+      if (typeof requestedAdapter === 'string') {
+        set(conf, 'pouchConfig.db', require(requestedAdapter)); // eslint-disable-line
+      }
     }
 
     // build db and cache it

--- a/packages/coinstac-ui/app/main/utils/boot/configure-core.js
+++ b/packages/coinstac-ui/app/main/utils/boot/configure-core.js
@@ -26,7 +26,9 @@ module.exports = function configureCore() {
       logger: app.logger,
       db: {
         pouchConfig: {
-          adapter: 'leveldb',
+          getAdapter(name) {
+            return name.includes('projects') ? 'leveldb' : 'memory';
+          },
         },
       },
     }

--- a/packages/coinstac-ui/app/main/utils/boot/configure-core.js
+++ b/packages/coinstac-ui/app/main/utils/boot/configure-core.js
@@ -6,11 +6,15 @@ const CoinstacClientCore = require('coinstac-client-core');
 const { merge } = require('lodash');
 const parseCLIInput = require('./parse-cli-input.js');
 const PouchDBAdapterLevelDB = require('pouchdb-adapter-leveldb');
+const PouchDBAdapterMemory = require('pouchdb-adapter-memory');
 const url = require('url');
 
 // TODO: Yeeikes
 common.services.dbRegistry.DBRegistry.Pouchy.PouchDB.plugin(
   PouchDBAdapterLevelDB
+);
+common.services.dbRegistry.DBRegistry.Pouchy.PouchDB.plugin(
+  PouchDBAdapterMemory
 );
 
 module.exports = function configureCore() {

--- a/packages/coinstac-ui/package.json
+++ b/packages/coinstac-ui/package.json
@@ -21,6 +21,7 @@
     "mkdirp": "^0.5.1",
     "moment": "^2.17.1",
     "pouchdb-adapter-leveldb": "^5.4.5",
+    "pouchdb-adapter-memory": "^6.0.5",
     "react": "^15.1.0",
     "react-bootstrap": "^0.30.0",
     "react-dom": "^15.1.0",


### PR DESCRIPTION
* **Problem:** Clients' state squashes or undesirably creates documents on the database server.
* **Solution:** Make all clients' databases in-memory except for `projects`.
* **Testing:**
  1. Launch UI and log in
  2. Create a consortium
  3. Create a project
  4. Completely kill the UI
  5. `ls ~/.coinstac/<USERNAME>/dbs` to ensure only project database is saved
  6. Relaunch UI and log in
  7. Observe project was persisted