### PR TITLE
Remove missing consortiumId on project page load

### DIFF
--- a/packages/coinstac-ui/app/render/components/projects/form-project-controller.js
+++ b/packages/coinstac-ui/app/render/components/projects/form-project-controller.js
@@ -59,16 +59,21 @@ class FormProjectController extends Component {
          *
          * @todo Investigate race conditions where a consortium's inputs change
          * while a user creates a project.
+         * @todo remove consortiumId clearing on bad find lookup
          */
-        this.state.project.computationInputs =
+        if (consortium) {
+          this.state.project.computationInputs =
           cloneDeep(consortium.activeComputationInputs);
 
-        if (deepEqual(
-          props.project.computationInputs,
-          consortium.activeComputationInputs
-        )) {
-          this.state.project.metaCovariateMapping =
+          if (deepEqual(
+            props.project.computationInputs,
+            consortium.activeComputationInputs
+          )) {
+            this.state.project.metaCovariateMapping =
             cloneDeep(props.project.metaCovariateMapping);
+          }
+        } else {
+          this.state.project.consortiumId = null;
         }
       }
     }


### PR DESCRIPTION
when a project page loads, remove the current consort ID if the find
lookup fails. This resolves removed consort messing up proj loads, but
should probably be revised once we stop clearing state on reboot.

closes #178 