### PR TITLE
Fix UI consort create crash

### DIFF
--- a/packages/coinstac-ui/app/render/components/consortium/consortium-form.js
+++ b/packages/coinstac-ui/app/render/components/consortium/consortium-form.js
@@ -266,10 +266,10 @@ function mapStateToProps(state, ownProps) {
     props.initialValues = ownProps.consortium;
   } else if (ownProps.computations) {
     // TODO: Don't hard-code default computation
+    const decentComp = ownProps.computations
+      .find(c => c.name === 'decentralized-single-shot-ridge-regression');
     props.initialValues = {
-      activeComputationId: ownProps.computations
-        .find(c => c.name === 'decentralized-single-shot-ridge-regression')
-        ._id,
+      activeComputationId: decentComp ? decentComp._id : null,
     };
   }
 


### PR DESCRIPTION
With hardcoded comps that fail lookup, accessing a prop on that lookup
crashes the UI :-( 

Fix: make it null. This means the consortia page loads but you can't really do anything, better than crashing the whole app.

Closes #174 