### PR TITLE
Fix remote computation document's start date bug.

### DIFF
--- a/packages/coinstac-common/src/models/computation/remote-computation-result.js
+++ b/packages/coinstac-common/src/models/computation/remote-computation-result.js
@@ -25,7 +25,8 @@ RemoteComputationResult.schema = Object.assign({}, ComputationResult.schema, {
   complete: joi.boolean().default(false), // DecentralizedComputation complete/halted
   computationInputs: joi.array().items(joi.array()).required(),
   endDate: joi.date().timestamp(),
-  startDate: joi.date().timestamp().default(Date.now()),
+  startDate: joi.date().timestamp()
+    .default(() => Date.now(), 'time of creation'),
   usernames: joi.array().items(joi.string()).default([]),
   userErrors: joi.array(),
   // runId - derived from _id, enforced on ComputationResult instantiation


### PR DESCRIPTION
* **Problem:** See #185.
* **Solution:** Use a function to make [joi `.default`](https://github.com/hapijs/joi/blob/master/API.md#anydefaultvalue-description) dynamic.
* **Testing:**
  1. Boot _coinstac-ui_.
  2. Wait a few minutes
  3. Run a multi-shot computation
  4. Observe accurate “Started _x_ minutes ago” in the status dashboard