### PR TITLE
Fix project deletion

### DIFF
--- a/packages/coinstac-ui/app/render/state/ducks/projects.js
+++ b/packages/coinstac-ui/app/render/state/ducks/projects.js
@@ -10,7 +10,10 @@ export const SET_PROJECTS = 'SET_PROJECTS';
 export const setProjects = (projects) => ({ type: SET_PROJECTS, projects });
 
 export const REMOVE_PROJECT = 'REMOVE_PROJECT';
-export const removeProject = (project) => ({ type: REMOVE_PROJECT, project });
+export const removeProject = (id) => ({
+  id,
+  type: REMOVE_PROJECT,
+});
 
 export const UPDATE_PROJECT_STATUS = 'UPDATE_PROJECT_STATUS';
 
@@ -101,20 +104,25 @@ export const addProject = applyAsyncLoading(project => {
   };
 });
 
-export const remove = applyAsyncLoading(project => {
-  return (dispatch) => {
-    return app.core.projects.delete(project)
-    .then((rslt) => {
+/**
+ * Remove a project.
+ *
+ * @param {Project} project
+ * @returns {Promise}
+ */
+export const remove = applyAsyncLoading(
+  project => dispatch => app.core.projects.delete(project).then(
+    (rslt) => {
       app.notify('success', `Project '${project.name}' removed`);
-      dispatch(removeProject(project));
+      dispatch(removeProject(project._id));
       return rslt;
-    })
-    .catch((err) => {
+    },
+    (err) => {
       app.notify('error', err.message);
       throw err;
-    });
-  };
-});
+    }
+  )
+);
 
 export const fetch = applyAsyncLoading(cb => {
   return (dispatch) => {
@@ -150,7 +158,7 @@ export default function reducer(projects = [], action) {
       }
       return [...action.projects];
     case REMOVE_PROJECT:
-      return projects.filter(p => p.name !== action.project.name);
+      return projects.filter(({ _id }) => _id !== action.id);
     case UPDATE_PROJECT_STATUS:
       return projects.map(p => {
         return p._id === action.id ?

--- a/packages/coinstac-ui/test/render/state/ducks/projects.js
+++ b/packages/coinstac-ui/test/render/state/ducks/projects.js
@@ -2,6 +2,7 @@ import app from 'ampersand-app';
 import noop from 'lodash/noop';
 import projectsReducer, {
   mapProject,
+  removeProject,
   updateProjectStatus,
   UPDATE_PROJECT_STATUS,
 } from '../../../../app/render/state/ducks/projects';
@@ -90,3 +91,22 @@ tape('Updates project status', t => {
 
   t.end();
 });
+
+tape('removes project', (t) => {
+  const projectId = 'delete-me';
+  const initialProjects = [{
+    _id: projectId,
+    name: 'Project to delete',
+  }, {
+    _id: 'save-me',
+    name: 'Project to save',
+  }];
+
+  t.deepEqual(
+    projectsReducer(initialProjects, removeProject(projectId)),
+    [initialProjects[1]],
+    'removes project from state'
+  );
+  t.end();
+});
+


### PR DESCRIPTION
* **Problem:** Project deletion in the `projects` reducer relied on a project’s `name` property, which isn’t guaranteed to be unique (see #193).
* **Solution:** Make the reducer and action creator delete on a project’s `_id`.
* **Testing:**
  1. Boot the UI
  2. Create a few (3+) projects
  3. Delete a project in the UI
  4. Observe the project is successfully removed