### PR TITLE
Computation run → redirect to status dashboard

### DIFF
--- a/packages/coinstac-ui/app/render/components/projects/projects-list.js
+++ b/packages/coinstac-ui/app/render/components/projects/projects-list.js
@@ -54,6 +54,8 @@ class ProjectsList extends Component {
   runComputation({ _id: projectId, consortiumId }) {
     const { dispatch } = this.props;
 
+    this.context.router.push('/');
+
     dispatch(runComputation({ consortiumId, projectId }))
       .catch((err) => {
         app.notify('error', err.message);
@@ -116,6 +118,12 @@ class ProjectsList extends Component {
     );
   }
 }
+
+ProjectsList.contextTypes = {
+  router: PropTypes.shape({
+    push: PropTypes.func.isRequired,
+  }).isRequired,
+};
 
 ProjectsList.propTypes = {
   consortia: PropTypes.arrayOf(PropTypes.shape({


### PR DESCRIPTION
* **Problem:** Computation run state is confusing to users. After they click the “Run Computation” button _what’s happening?!_ It’s unclear.
* **Solution:**
  Whisk them away to the status dashboard:

  ![do-it](https://cloud.githubusercontent.com/assets/1858316/24822701/0de0a192-1bac-11e7-9c65-c942e2df32a8.gif)

  _(Bonus: users can’t click “Run Computation” tons of times.)_
* **Testing:**
  1. Boot a couple clients
  2. Set up a consortium/projects and run a computation
  3. Observe redirect

