### PR TITLE
Correct covariates’ order in results table

### DIFF
--- a/packages/coinstac-ui/app/render/components/consortium/consortium-result.js
+++ b/packages/coinstac-ui/app/render/components/consortium/consortium-result.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react';
 import { Collapse, Label } from 'react-bootstrap';
 import classNames from 'classnames';
 import moment from 'moment';
-import { reduce } from 'lodash';
+import { camelCase, reduce } from 'lodash';
 
 import ConsortiumResultMeta from './consortium-result-meta';
 import ConsortiumResultTable from './consortium-result-table';
@@ -61,10 +61,15 @@ export default function ConsortiumResult({
      * @todo This assumes covariates are placed at a specific location in
      * `computationInputs`. Don't hard-code this!
      */
-    const covariates =
+    const covariatesIndex =
       computation.name === 'decentralized-single-shot-ridge-regression' ?
-      computationInputs[0][2].map(x => x.name) :
-      computationInputs[0][3].map(x => x.name);
+      2 :
+      3;
+
+    const covariates = computationInputs[0][covariatesIndex]
+      .slice(0)
+      .sort(ConsortiumResult.sortCovariates)
+      .map(x => x.name);
 
     dataOutput = (
       <div>
@@ -150,7 +155,6 @@ export default function ConsortiumResult({
 ConsortiumResult.displayName = 'ConsortiumResult';
 
 ConsortiumResult.propTypes = {
-
   complete: PropTypes.bool.isRequired,
   computation: PropTypes.shape({
     meta: PropTypes.shape({
@@ -183,3 +187,6 @@ ConsortiumResult.propTypes = {
   usernames: PropTypes.array.isRequired,
   userErrors: PropTypes.array.isRequired,
 };
+
+ConsortiumResult.sortCovariates = ({ name: a }, { name: b }) =>
+  camelCase(a) > camelCase(b);


### PR DESCRIPTION
* **Problem:** covariates’ order in the results table is incorrect (see #186).
* **Solution:** Sort covariates in the UI to match their sort order in the computation:
  1. The client [converts covariates to camelCase](https://github.com/MRN-Code/coinstac/blob/39f4035e00558746ba9687c36024ed46a254f73c/packages/coinstac-client-core/src/sub-api/project-service.js#L180) in each file’s `.tags` map
  2. The computations [alpha-sort the each file’s `.tags`’s properties](https://github.com/MRN-Code/decentralized-single-shot-ridge-regression/blob/d4a5b270a085ce191f1a24cae729fd89500fa65a/src/index.js#L49)
* **Testing:**
  1. Run a computation
  2. Ensure results table’s covariates are alpha-sorted