### PR TITLE
Add tooltip to results’ “Global” heading

### DIFF
--- a/packages/coinstac-ui/app/render/components/consortium/consortium-result-table.js
+++ b/packages/coinstac-ui/app/render/components/consortium/consortium-result-table.js
@@ -97,7 +97,10 @@ ConsortiumResultTable.propTypes = {
   betaVector: PropTypes.arrayOf(PropTypes.number).isRequired,
   covariates: PropTypes.arrayOf(PropTypes.string).isRequired,
   degreesOfFreedom: PropTypes.number.isRequired,
-  name: PropTypes.string.isRequired,
+  name: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.string,
+  ]).isRequired,
   pValue: PropTypes.arrayOf(PropTypes.number).isRequired,
   rSquared: PropTypes.number.isRequired,
   tValue: PropTypes.arrayOf(PropTypes.number).isRequired,

--- a/packages/coinstac-ui/app/render/components/consortium/consortium-result.js
+++ b/packages/coinstac-ui/app/render/components/consortium/consortium-result.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import { Collapse, Label } from 'react-bootstrap';
+import { Collapse, Label, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import classNames from 'classnames';
 import moment from 'moment';
 import { reduce } from 'lodash';
@@ -74,13 +74,25 @@ export default function ConsortiumResult({
            * data under the `global` property.
            */
           if (prop === 'global') {
+            const tooltip =
+              computation.name === 'decentralized-single-shot-ridge-regression' ?
+                <Tooltip id="tooltip">Meta-analysis (averaging)</Tooltip> :
+                <Tooltip id="tooltip">Mega-analysis</Tooltip>;
+            const name = (
+              <OverlayTrigger overlay={tooltip} placement="right">
+                <span>
+                  Global
+                  <Label>?</Label>
+                </span>
+              </OverlayTrigger>
+            );
             return [
               <ConsortiumResultTable
                 betaVector={item.betaVector}
                 covariates={covariates}
                 degreesOfFreedom={item.degreesOfFreedom}
                 key={prop}
-                name={'Global'}
+                name={name}
                 pValue={item.pValue}
                 rSquared={item.rSquared}
                 tValue={item.tValue}

--- a/packages/coinstac-ui/app/render/styles/consortium-result.scss
+++ b/packages/coinstac-ui/app/render/styles/consortium-result.scss
@@ -8,6 +8,17 @@
   font-weight: 700;
   margin: 32px 0 8px;
   padding: 12px 8px 0;
+
+  .label {
+    border-radius: 100%;
+    display: inline-block;
+    font-size: 1.15rem;
+    line-height: 1.5em;
+    margin-left: .5em;
+    padding: 0;
+    vertical-align: top;
+    width: 1.5em;
+  }
 }
 
 .consortium-result samp {


### PR DESCRIPTION
* **Problem:** The “Global” heading in the computation result table doesn’t make sense to users (see #192).
* **Solution:** Clarify the headings’ meanings with a computation-aware tooltip
* **Testing:**
  1. Run a computation in the UI
  2. Observe the tooltip in the result table