### PR TITLE
Bugfix/consortium form clearing

### DIFF
--- a/packages/coinstac-ui/app/render/components/consortium/consortium-computation-inputs-viewer.js
+++ b/packages/coinstac-ui/app/render/components/consortium/consortium-computation-inputs-viewer.js
@@ -61,11 +61,14 @@ ConsortiumComputationInputsViewer.propTypes = {
     label: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,
   })).isRequired,
-  values: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.oneOfType([
+  values: PropTypes.arrayOf(PropTypes.oneOfType([
     PropTypes.number,
-    PropTypes.string,
-    PropTypes.shape({
-      name: PropTypes.string.isRequired,
-    }),
-  ]))).isRequired,
+    PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.string),
+      PropTypes.arrayOf(PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        type: PropTypes.string.isRequired,
+      })),
+    ]),
+  ])).isRequired,
 };

--- a/packages/coinstac-ui/app/render/components/consortium/consortium-form.js
+++ b/packages/coinstac-ui/app/render/components/consortium/consortium-form.js
@@ -246,12 +246,29 @@ const selector = formValueSelector(ConsortiumForm.FORM_NAME);
  * @param {Object} ownProps
  */
 function mapStateToProps(state, { computations, consortium, isNew, isOwner }) {
-  const formValue = selector(state, 'activeComputationId');
+  /**
+   * Redux-Form's selector
+   * {@link http://redux-form.com/6.6.3/docs/api/FormValueSelector.md/#selector}
+   */
+  const formValues = selector(
+    state,
+    'activeComputationId',
+    'description',
+    'label'
+  );
   const initialValues = consortium ? cloneDeep(consortium) : {};
   let activeComputationId;
 
-  if (formValue) {
-    activeComputationId = formValue;
+  if (formValues.description) {
+    initialValues.description = formValues.description;
+  }
+
+  if (formValues.label) {
+    initialValues.label = formValues.label;
+  }
+
+  if (formValues.activeComputationId) {
+    activeComputationId = formValues.activeComputationId;
   } else if (initialValues.activeComputationId) {
     activeComputationId = initialValues.activeComputationId;
   } else {
@@ -318,9 +335,7 @@ function mapStateToProps(state, { computations, consortium, isNew, isOwner }) {
 }
 
 export default connect(mapStateToProps)(reduxForm({
-  // destroyOnUnmount: false,
   enableReinitialize: true,
   form: ConsortiumForm.FORM_NAME,
-  // keepDirtyOnReinitialize: true,
   validate: ConsortiumForm.validate,
 })(ConsortiumForm));

--- a/packages/coinstac-ui/package.json
+++ b/packages/coinstac-ui/package.json
@@ -34,7 +34,7 @@
     "read-last-lines": "^1.1.0",
     "redux": "^3.5.2",
     "redux-devtools": "^3.3.1",
-    "redux-form": "^6.6.1",
+    "redux-form": "^6.6.3",
     "redux-logger": "^3.0.1",
     "redux-promise": "^0.5.0",
     "redux-thunk": "^2.1.0",

--- a/packages/coinstac-ui/webpack.config.js
+++ b/packages/coinstac-ui/webpack.config.js
@@ -121,7 +121,7 @@ if (process.env.NODE_ENV === 'development') {
   );
 
   config.entry.unshift(
-    require.resolve('webpack-dev-server/client') + `?http://localhost:${port}`,
+    `${require.resolve('webpack-dev-server/client')}?http://localhost:${port}`,
     require.resolve('webpack/hot/dev-server')
   );
 

--- a/packages/coinstac-ui/webpack.config.js
+++ b/packages/coinstac-ui/webpack.config.js
@@ -115,7 +115,10 @@ if (process.env.NODE_ENV === 'development') {
 
   // Massage configuration for hot module replacement:
   config.output.publicPath = `http://localhost:${port}/`;
-  config.plugins.push(new webpack.HotModuleReplacementPlugin());
+  config.plugins.push(
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.NamedModulesPlugin()
+  );
 
   config.entry.unshift(
     require.resolve('webpack-dev-server/client') + `?http://localhost:${port}`,


### PR DESCRIPTION
#### Problem

Changing active computations in the consortium form clears the label and description.

![where-it-go](https://cloud.githubusercontent.com/assets/1858316/25470805/cd791b70-2ad8-11e7-84ee-3088d56c9c12.gif)

#### Solution

Use [redux-form’s `formValueSelector`](http://redux-form.com/6.6.3/docs/api/FormValueSelector.md/) to persist dirty form state in the `initialValues` property.

#### Testing

1. Boot the UI
2. Open the consortium creation form
3. Fill out “label” and “description” fields
4. Change the active computation
5. Observe “label” and “description” aren’t cleared!