### PR TITLE
Document Conflict In Multi-Site Run

### DIFF
--- a/packages/coinstac-ui/app/render/state/ducks/bg-services.js
+++ b/packages/coinstac-ui/app/render/state/ducks/bg-services.js
@@ -44,48 +44,49 @@ export const joinSlaveComputation = (consortium) => {
       app.core.computations.shouldJoinRun(consortiumId, currentRunHist === true),
     ]);
   })
-    .then(([project, runId, shouldJoinRun]) => {
-      const proceedWithRun = (doRun) => {
-        let runProm;
-        if (doRun) {
-          const onRunError = getRunErrorNotifier(consortium);
+  .then(([project, runId, shouldJoinRun]) => {
+    const proceedWithRun = (doRun) => {
+      let runProm;
+      if (doRun) {
+        const onRunError = getRunErrorNotifier(consortium);
 
-          computationStartNotification(consortium);
-          app.core.pool.events.on('error', onRunError);
-          app.core.pool.events.once('computation:complete', () => {
-            computationCompleteNotification(consortium);
-            app.core.pool.events.removeListener('error', onRunError);
+        computationStartNotification(consortium);
+        app.core.pool.events.on('error', onRunError);
+        app.core.pool.events.once('computation:complete', () => {
+          computationCompleteNotification(consortium);
+          app.core.pool.events.removeListener('error', onRunError);
+        });
+
+        if (alreadyRan[runId]) {
+          runProm = app.core.computations.joinRun({
+            consortiumId,
+            projectId: project._id,
+            runId,
           });
-
-          if (alreadyRan[runId]) {
-            runProm = app.core.computations.joinRun({
-              consortiumId,
-              projectId: project._id,
-              runId,
-            });
-          }
+        } else {
           runProm = app.core.computations.joinSlavedRun({
             consortiumId,
             projectId: project._id,
             runId,
           });
-
-          alreadyRan[runId] = true;
-          return runProm;
         }
-      };
 
-      if (project && runId && shouldJoinRun) {
-        if (currentRunHist !== alreadyRan[consortium._id]) {
-          // current hist has changed, prob not the first run now, check if we can
-          // run again
-          return app.core.computations
-          .shouldJoinRun(consortiumId, alreadyRan[consortium._id] === true)
-          .then(proceedWithRun);
-        }
-        return proceedWithRun(shouldJoinRun);
+        alreadyRan[runId] = true;
+        return runProm;
       }
-    });
+    };
+
+    if (project && runId && shouldJoinRun) {
+      if (currentRunHist !== alreadyRan[consortium._id]) {
+        // current hist has changed, prob not the first run now, check if we can
+        // run again
+        return app.core.computations
+        .shouldJoinRun(consortiumId, alreadyRan[consortium._id] === true)
+        .then(proceedWithRun);
+      }
+      return proceedWithRun(shouldJoinRun);
+    }
+  });
 };
 
 export const addConsortiumComputationListener = (consortium) => {


### PR DESCRIPTION
* **Problem:** Running a ridge regression with multiple sites can result in those sites receiving a *Document Conflict* error.
* **Solution:** Wrap `joinSlavedRun` in `else` statement.
* **Test:** Run a ridge regression with multiple clients. Run a second time after the first completes and notice no *Document Conflict* errors.

Resolves #224 