### PR TITLE
remove check from lower level common, keep mem/disk check in config

### DIFF
--- a/packages/coinstac-common/src/services/classes/db-registry.js
+++ b/packages/coinstac-common/src/services/classes/db-registry.js
@@ -195,8 +195,6 @@ class DBRegistry {
      */
     if (
       this.localStores &&
-      this.localStores.indexOf('projects') > -1 &&
-      this.localStores.indexOf('local-consortium') > -1 &&
       conf.pouchConfig.getAdapter instanceof Function
     ) {
       conf.pouchConfig.adapter = conf.pouchConfig.getAdapter(connStr);

--- a/packages/coinstac-ui/app/main/utils/boot/configure-core.js
+++ b/packages/coinstac-ui/app/main/utils/boot/configure-core.js
@@ -27,7 +27,8 @@ module.exports = function configureCore() {
       db: {
         pouchConfig: {
           getAdapter(name) {
-            return name.includes('projects') ? 'leveldb' : 'memory';
+            return name.includes('projects') ||
+             name.includes('local-consortium') ? 'leveldb' : 'memory';
           },
         },
       },


### PR DESCRIPTION
#Problem
Hey, state clearing isnt working....

#Solution
It appears that the check for which mem/disk adapters we use for the DB's happens in two places (kinda). Simplify that logic, make it one place more or less, and blamo, fixed.