### PR TITLE
Single Digit Files Collection Names

### DIFF
--- a/packages/coinstac-common/src/models/project.js
+++ b/packages/coinstac-common/src/models/project.js
@@ -15,7 +15,7 @@ const joi = require('joi');
 class Project extends PouchDocument {}
 
 Project.schema = Object.assign({
-  name: joi.string().min(1).regex(/[a-zA-Z]+/, 'at least one character')
+  name: joi.string().min(1).regex(/[a-zA-Z0-9]+/, 'at least one character')
     .required(),
 
   /**


### PR DESCRIPTION
* **Problem:**
   1. Project names (Files Collection names) containing a single digit fail validation and prevent a user from submitting the form to create a new collection.
* **Solution:**
   1. Modify regex to allow numbers.
* **Test:**
   1. Login to application.
   1. Click on *My Files* tab.
   1. Fill out form, being sure to enter a single digit in the *Name* field.
   1. Observe that the collection is created without issue.