### PR TITLE
Updating Archiver Package Allows for Working Tars

### DIFF
--- a/packages/coinstac-ui/package.json
+++ b/packages/coinstac-ui/package.json
@@ -45,7 +45,7 @@
     "winston": "^2.3.1"
   },
   "devDependencies": {
-    "archiver": "^1.3.0",
+    "archiver": "^2.0.0",
     "babel-cli": "^6.24.1",
     "babel-core": "^6.24.1",
     "babel-loader": "^6.4.1",


### PR DESCRIPTION
* **Problem:**
   1. Building COINSTAC on Macs produces a broken tar archive.
* **Solution:**
   1. Update the `archiver` library to version `2.0.0`.
* **Tests:**
   1. `npm run build` in base directory
   1. `npm run build` in coinstac-ui directory
   1. Decompress `/packages/coinstac-ui/coinstac-darwin-x64.tar.gz` and run the enclosed application.