### PR TITLE
Fix login and allow new inspector debugging protocol

### DIFF
--- a/packages/coinstac-client-core/test/sub-api/authentication-service.js
+++ b/packages/coinstac-client-core/test/sub-api/authentication-service.js
@@ -20,7 +20,7 @@ function getUser() {
     password: 'bobbobbob',
     passwordExpDate: Date.now(),
     passwordResetExpiration: undefined,
-    passwordResetKey: undefined,
+    passwordResetHash: undefined,
     passwordResetSessionId: undefined,
     siteId: '7',
     username: 'bob',

--- a/packages/coinstac-common/src/models/user.js
+++ b/packages/coinstac-common/src/models/user.js
@@ -29,7 +29,7 @@ User.schema = Object.assign({
   password: joi.string().min(5),
   passwordExpDate: joi.any(),
   passwordResetExpiration: joi.date().allow(null),
-  passwordResetKey: joi.string().allow(null),
+  passwordResetHash: joi.string().allow(null),
   passwordResetSessionId: joi.string().allow(null),
   siteId: joi.any(),
   username: joi.string().min(3).regex(/^[^-]+$/)

--- a/packages/coinstac-ui/app/main/utils/boot/parse-cli-input.js
+++ b/packages/coinstac-ui/app/main/utils/boot/parse-cli-input.js
@@ -9,6 +9,7 @@ let appOpts;
 function parse() {
   if (process.defaultApp) {
     const opts = program
+    .allowUnknownOption()
     .option('-dev, --development', 'run in development mode (NODE_ENV === "development")')
     .option('-w, --webpack', 'boot webpack dev server as child process')
     .option('--log-level [level]', 'set log level (silly/verbose/info/warn/error)')

--- a/packages/coinstac-ui/package.json
+++ b/packages/coinstac-ui/package.json
@@ -57,7 +57,7 @@
     "cross-env": "^2.0.1",
     "css-loader": "^0.28.4",
     "devtron": "^1.4.0",
-    "electron": "1.5.1",
+    "electron": "^1.7.6",
     "electron-debug": "^1.1.0",
     "electron-packager": "^8.7.1",
     "file-loader": "^0.11.1",


### PR DESCRIPTION
# Problem(s) and fix(es)
The user model used for login was broken due to an upstream DB change,
this is fixed. Updated electron to use new inspector protocol for
debugging, this necessitated a change to the arg parsing.

To use the new inspector protocol add the following line to the relevant section in your VSCode `launch.json`

```
            "protocol": "inspector",
```
This also probably requires the latest version of VSCode as well.