### PR TITLE
Sim - fix clientcount as string issue

### DIFF
--- a/packages/coinstac-simulator/src/index.js
+++ b/packages/coinstac-simulator/src/index.js
@@ -16,6 +16,8 @@ const startRun = ({ spec, runMode = 'local', clientCount = 1, operatingDirectory
   const pipelines = {
     locals: [],
   };
+  clientCount = parseInt(clientCount, 10);
+
   if (runMode === 'decentralized') {
     const remoteManager = Pipeline.create({
       clientId: 'remote',


### PR DESCRIPTION
# Problem
Crashes on more than one decent client

# Solution
The client list was not being properly generated due to the count being a string #js, cast to int.