### PR TITLE
Can view pipelinesnapshots on pipeline page

### DIFF
--- a/packages/coinstac-ui/app/render/components/common/result-item.jsx
+++ b/packages/coinstac-ui/app/render/components/common/result-item.jsx
@@ -9,24 +9,38 @@ const ResultItem = ({ runObject, consortia }) => (
     key={runObject.id}
     header={<h3>{`
       ${consortia.filter(con => con.id === runObject.consortiumId)[0].name}`}
-      {' - Started: '}
       {runObject.startDate &&
+      <div className="pull-right">{'Created: '}
         <TimeStamp
           time={runObject.startDate / 1000}
           precision={2}
           autoUpdate={10}
-          format="full"
-        />}
-      {' - Ended: '}
-      {runObject.endDate &&
-        <TimeStamp
-          time={runObject.endDate / 1000}
-          precision={2}
-          autoUpdate={10}
-          format="full"
-        />}
+          format="ago"
+        />
+        </div>}
     </h3>}
   >
+    {runObject.startDate &&
+    <div>Start date:
+      <TimeStamp
+        time={runObject.startDate / 1000}
+        precision={2}
+        autoUpdate={10}
+        format="date"
+      />
+    </div>}
+    {runObject.endDate &&
+    <div>End date:
+      <TimeStamp
+        time={runObject.endDate / 1000}
+        precision={2}
+        autoUpdate={10}
+        format="date"
+      />
+    </div>}
+    {!runObject.endDate &&
+      <div>In Progress</div>
+    }
     {runObject.clients &&
     <p>Clients: {runObject.clients}</p>
     }
@@ -40,7 +54,7 @@ const ResultItem = ({ runObject, consortia }) => (
     </Panel>}
     {runObject.pipelineSnapshot &&
     <LinkContainer
-      to={`dashboard/pipelines/${runObject.pipelineSnapshot.id}`}
+      to={`dashboard/pipelines/snapShot/${runObject.pipelineSnapshot.id}`}
     >
       <Button bsStyle="info">View Pipeline</Button>
     </LinkContainer>

--- a/packages/coinstac-ui/app/render/components/pipelines/pipeline.jsx
+++ b/packages/coinstac-ui/app/render/components/pipelines/pipeline.jsx
@@ -54,7 +54,7 @@ class Pipeline extends Component {
     super(props);
 
     let consortium = null;
-    const pipeline = {
+    let pipeline = {
       name: '',
       description: '',
       owningConsortium: '',
@@ -67,6 +67,12 @@ class Pipeline extends Component {
       const data = props.client.readQuery({ query: FETCH_ALL_CONSORTIA_QUERY });
       consortium = data.fetchAllConsortia.find(cons => cons.id === props.params.consortiumId);
       pipeline.owningConsortium = consortium.id;
+    }
+
+    if (props.params.runId) {
+      const runs = props.runs;
+      runs.filter(run => run.id === props.params.runId);
+      pipeline = runs[0].pipelineSnapshot;
     }
 
     this.state = {
@@ -109,9 +115,13 @@ class Pipeline extends Component {
 
   setConsortium() {
     const { auth: { user }, client } = this.props;
-    const owner = user.permissions.consortia[this.state.pipeline.owningConsortium] &&
+    let owner;
+    if (this.props.params.runId) {
+      owner = false;
+    } else {
+      owner = user.permissions.consortia[this.state.pipeline.owningConsortium] &&
       user.permissions.consortia[this.state.pipeline.owningConsortium].write;
-
+    }
     const consortiumId = this.state.pipeline.owningConsortium;
     const data = client.readQuery({ query: FETCH_ALL_CONSORTIA_QUERY });
     const consortium = data.fetchAllConsortia.find(cons => cons.id === consortiumId);
@@ -508,6 +518,7 @@ class Pipeline extends Component {
 
 Pipeline.defaultProps = {
   activePipeline: null,
+  runs: null,
   subscribeToComputations: null,
   subscribeToPipelines: null,
 };
@@ -520,6 +531,7 @@ Pipeline.propTypes = {
   connectDropTarget: PropTypes.func.isRequired,
   consortia: PropTypes.array.isRequired,
   params: PropTypes.object.isRequired,
+  runs: PropTypes.array,
   savePipeline: PropTypes.func.isRequired,
   subscribeToPipelines: PropTypes.func,
 };

--- a/packages/coinstac-ui/app/render/routes.jsx
+++ b/packages/coinstac-ui/app/render/routes.jsx
@@ -45,6 +45,7 @@ export default (
         <IndexRoute component={PipelinesList} />
         <Route path="new(/:consortiumId)" component={Pipeline} />
         <Route path=":pipelineId" component={Pipeline} />
+        <Route path="snapShot(/:runId)" component={Pipeline} />
       </Route>
       <Route path="results" component={RouteContainer}>
         <IndexRoute component={ResultsList} />


### PR DESCRIPTION
close #385

Can now view pipelinesnapshots on pipeline page. The user will not be able to change any data as it is a reference to the pipeline as it was when the run was created. In this PR I also have UI visual changes to results-list-item due to feedback.