### PR TITLE
Pipeline: Bug/remove remove mapping

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,3 @@
+# Problem
+
+# Tasks

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,6 @@
+# Problem
+referenced issue(s):
+
+# Solution
+
+# Testing

--- a/packages/coinstac-pipeline/src/pipeline.js
+++ b/packages/coinstac-pipeline/src/pipeline.js
@@ -24,7 +24,11 @@ module.exports = {
         }
       });
     };
-    prepCache(steps);
+
+    // remote doesn't get any step input, happens all client side
+    if (mode !== 'remote') {
+      prepCache(steps);
+    }
     return {
       cache,
       currentStep,
@@ -52,8 +56,7 @@ module.exports = {
         };
         return pipelineSteps.reduce((prom, step, index) => {
           this.currentStep = index;
-          // runInput = index > 0 ? runInput : inputMap[index];
-          return prom.then(() => step.start(loadInput(step), remoteHandler))
+          return prom.then(() => step.start(this.mode === 'remote' ? {} : loadInput(step), remoteHandler))
           .then((output) => {
             loadCache(output, index);
             return output;


### PR DESCRIPTION
# Problem
Remote could possibly break on a unfulfilled spec from an Owner pipeline start, but remotes dont really use the input map in specs anyway....

# Solution
Remote no longer use given inputmaps