### PR TITLE
Sim + pipeline: add pipeline status as well as interactivity to sim

### DIFF
--- a/packages/coinstac-client-core/package-lock.json
+++ b/packages/coinstac-client-core/package-lock.json
@@ -3735,14 +3735,6 @@
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -3761,6 +3753,14 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.10.0",
         "function-bind": "1.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/packages/coinstac-common/package-lock.json
+++ b/packages/coinstac-common/package-lock.json
@@ -2,6 +2,15 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "JSONStream": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
+      "integrity": "sha1-dDSdDYlSK3HzDwoD/5vSDKbxKsA=",
+      "requires": {
+        "jsonparse": "0.0.5",
+        "through": "2.3.8"
+      }
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -851,8 +860,8 @@
       "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-1.0.4.tgz",
       "integrity": "sha512-pkXB9p7KWagegOXm2NsbVDBluQQLCBJzX9uYJzVbL6CHwe4d2sSbcACJ4K8ISX1l1JUUmFSiwNkBKc1uTiU4MA==",
       "requires": {
-        "debug": "2.6.9",
         "JSONStream": "0.10.0",
+        "debug": "2.6.9",
         "readable-stream": "1.0.34",
         "split-ca": "1.0.1"
       },
@@ -2264,15 +2273,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
-    },
-    "JSONStream": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
-      "integrity": "sha1-dDSdDYlSK3HzDwoD/5vSDKbxKsA=",
-      "requires": {
-        "jsonparse": "0.0.5",
-        "through": "2.3.8"
-      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -8586,14 +8586,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -8602,6 +8594,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "5.1.1"
           }
         },
         "stringstream": {
@@ -8767,11 +8767,6 @@
         }
       }
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -8791,6 +8786,11 @@
         "es-abstract": "1.10.0",
         "function-bind": "1.1.1"
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "0.0.5",

--- a/packages/coinstac-docker-manager/package-lock.json
+++ b/packages/coinstac-docker-manager/package-lock.json
@@ -2,6 +2,15 @@
 	"requires": true,
 	"lockfileVersion": 1,
 	"dependencies": {
+		"JSONStream": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
+			"integrity": "sha1-dDSdDYlSK3HzDwoD/5vSDKbxKsA=",
+			"requires": {
+				"jsonparse": "0.0.5",
+				"through": "2.3.8"
+			}
+		},
 		"ajv": {
 			"version": "5.5.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -145,8 +154,8 @@
 			"resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-1.0.4.tgz",
 			"integrity": "sha512-pkXB9p7KWagegOXm2NsbVDBluQQLCBJzX9uYJzVbL6CHwe4d2sSbcACJ4K8ISX1l1JUUmFSiwNkBKc1uTiU4MA==",
 			"requires": {
-				"debug": "2.6.9",
 				"JSONStream": "0.10.0",
+				"debug": "2.6.9",
 				"readable-stream": "1.0.34",
 				"split-ca": "1.0.1"
 			},
@@ -332,15 +341,6 @@
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
 			"integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ="
-		},
-		"JSONStream": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
-			"integrity": "sha1-dDSdDYlSK3HzDwoD/5vSDKbxKsA=",
-			"requires": {
-				"jsonparse": "0.0.5",
-				"through": "2.3.8"
-			}
 		},
 		"jsprim": {
 			"version": "1.4.1",

--- a/packages/coinstac-pipeline/package-lock.json
+++ b/packages/coinstac-pipeline/package-lock.json
@@ -2413,13 +2413,6 @@
 						}
 					}
 				},
-				"string_decoder": {
-					"version": "1.0.1",
-					"bundled": true,
-					"requires": {
-						"safe-buffer": "5.0.1"
-					}
-				},
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
@@ -2427,6 +2420,13 @@
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
 						"strip-ansi": "3.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"safe-buffer": "5.0.1"
 					}
 				},
 				"stringstream": {
@@ -5918,14 +5918,6 @@
 			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
 		},
-		"string_decoder": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-			"requires": {
-				"safe-buffer": "5.1.1"
-			}
-		},
 		"string-width": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -5933,6 +5925,14 @@
 			"requires": {
 				"is-fullwidth-code-point": "2.0.0",
 				"strip-ansi": "4.0.0"
+			}
+		},
+		"string_decoder": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"requires": {
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"stringstream": {

--- a/packages/coinstac-pipeline/src/controller.js
+++ b/packages/coinstac-pipeline/src/controller.js
@@ -22,7 +22,7 @@ module.exports = {
     const currentComputations = computations.map(comp => Computation.create(comp, mode, runId));
     const activeControlBox = controllers[controller.type];
     const computationStep = 0;
-    const iterationEmitter = new Emitter();
+    const stateEmitter = new Emitter();
     const controllerState = {
       activeComputations: [],
       baseDirectory: `/input/${runId}`,
@@ -37,9 +37,9 @@ module.exports = {
       runType: 'sequential',
       state: undefined,
     };
-    const setIteration = (iteration) => {
-      controllerState.iteration = iteration;
-      iterationEmitter.emit('update', iteration, cache, controllerState.currentOutput);
+    const setStateProp = (prop, val) => {
+      controllerState[prop] = val;
+      stateEmitter.emit('update', controllerState);
     };
 
     return {
@@ -49,10 +49,10 @@ module.exports = {
       controllerState,
       mode,
       runId,
-      iterationEmitter,
+      stateEmitter,
       inputMap,
       operatingDirectory,
-      setIteration,
+      setStateProp,
       /**
        * Starts a controller, which in turn starts a computation, given the correct
        * conditions.
@@ -62,7 +62,7 @@ module.exports = {
        */
       start: (input, remoteHandler) => {
         const queue = [];
-        controllerState.state = 'started';
+        setStateProp('state', 'started');
         controllerState.remoteInitial = controllerState.mode === 'remote' ? true : undefined;
         if (!controllerState.initialized) {
           controllerState.runType = activeControlBox.runType || controllerState.runType;
@@ -70,7 +70,7 @@ module.exports = {
           controllerState.computationIndex = 0;
           controllerState.activeComputations[controllerState.computationIndex] =
             controllerState.currentComputations[controllerState.computationIndex];
-          setIteration(0);
+          setStateProp('iteration', 0);
         }
 
         /**
@@ -84,8 +84,8 @@ module.exports = {
           // TODO: logic for different runTypes (single, parallel, etc)
           switch (controllerState.currentBoxCommand) {
             case 'nextIteration':
-              setIteration(controllerState.iteration + 1);
-              controllerState.state = 'waiting on computation';
+              setStateProp('iteration', controllerState.iteration + 1);
+              setStateProp('state', 'waiting on computation');
 
               return controllerState.activeComputations[controllerState.computationIndex]
               .start(
@@ -95,7 +95,7 @@ module.exports = {
               .then((output) => {
                 cache = Object.assign(cache, output.cache);
                 controllerState.currentOutput = { output: output.output, success: output.success };
-                controllerState.state = 'finished iteration';
+                setStateProp('state', 'finished iteration');
                 cb(output.output);
               }).catch(error => err(error));
             case 'nextComputation':
@@ -108,30 +108,30 @@ module.exports = {
               //   .start(input);
               break;
             case 'remote':
-              controllerState.state = 'waiting on remote';
+              setStateProp('state', 'waiting on remote');
               return remoteHandler({ input: controllerState.currentOutput })
               .then((output) => {
-                controllerState.state = 'finished remote iteration';
+                setStateProp('state', 'finished remote iteration');
                 controllerState.currentOutput = { output: output.output, success: output.success };
                 cb(output.output);
               }).catch(error => err(error));
             case 'firstServerRemote':
               // TODO: not ideal, figure out better remote start
               // remove noop need
-              controllerState.state = 'waiting on remote';
+              setStateProp('state', 'waiting on remote');
               return remoteHandler({ input: controllerState.currentOutput, noop: true })
               .then((output) => {
-                controllerState.state = 'finished remote iteration';
+                setStateProp('state', 'finished remote iteration');
                 controllerState.currentOutput = { output: output.output, success: output.success };
                 cb(output.output);
               }).catch(error => err(error));
             case 'doneRemote':
-              controllerState.state = 'waiting on remote';
+              setStateProp('state', 'waiting on remote');
               // we want the success output, grabbing the last currentOutput is fine
               // Note that input arg === controllerState.currentOutput.output at this point
               return remoteHandler({ input: controllerState.currentOutput, transmitOnly: true })
               .then(() => {
-                controllerState.state = 'finished final remote iteration';
+                setStateProp('state', 'finished final remote iteration');
                 cb(input);
               }).catch(error => err(error));
             case 'done':
@@ -171,7 +171,7 @@ module.exports = {
          * @return {Object}                computation's result
          */
         const waterfall = (initialInput, steps, done, err) => {
-          controllerState.state = 'running';
+          setStateProp('state', 'running');
           steps.push(done);
           trampoline(() => {
             return steps.length ?
@@ -206,7 +206,7 @@ module.exports = {
           };
 
           waterfall(input, queue, (result) => {
-            controllerState.state = 'stopped';
+            setStateProp('state', 'stopped');
             controllerState.activeComputations[controllerState.computationIndex].stop()
             .then(() => res(result));
           }, errCb);

--- a/packages/coinstac-pipeline/src/pipeline-manager.js
+++ b/packages/coinstac-pipeline/src/pipeline-manager.js
@@ -221,6 +221,13 @@ module.exports = {
 
         return { pipeline: activePipelines[runId].pipeline, result: pipelineProm };
       },
+      getPipelineStateListener(runId) {
+        if (!this.activePipelines[runId]) {
+          throw new Error('invalid pipeline ID');
+        }
+
+        return this.activePipelines[runId].pipeline.stateEmitter;
+      },
       waitingOn,
     };
   },

--- a/packages/coinstac-pipeline/src/pipeline.js
+++ b/packages/coinstac-pipeline/src/pipeline.js
@@ -1,15 +1,18 @@
 'use strict';
 
 const Controller = require('./controller');
+const Emitter = require('events');
 
 module.exports = {
   create({ steps }, runId, { mode, operatingDirectory }) {
     const cache = {};
     let currentStep;
 
-    const pipelineSteps = steps.map(
-      step => Controller.create(step, runId, { mode, operatingDirectory })
-    );
+    const stateEmitter = new Emitter();
+
+
+    const pipelineSteps = steps.map(step =>
+      Controller.create(step, runId, { mode, operatingDirectory }));
 
     const prepCache = (pipelineSpec) => {
       pipelineSpec.forEach((step) => {
@@ -25,6 +28,7 @@ module.exports = {
       });
     };
 
+
     // remote doesn't get any step input, happens all client side
     if (mode !== 'remote') {
       prepCache(steps);
@@ -34,8 +38,31 @@ module.exports = {
       currentStep,
       id: runId,
       mode,
+      stateEmitter,
       pipelineSteps,
       run(remoteHandler) {
+        const packageState = () => {
+          const ctrs = this.pipelineSteps[this.currentStep].controllerState;
+          return {
+            currentIteration: ctrs.iteration,
+            controllerState: ctrs.state,
+            pipelineStep: this.currentStep,
+            mode: this.mode,
+            totalSteps: this.pipelineSteps.length,
+          };
+        };
+
+        const setStateProp = (prop, val) => {
+          this[prop] = val;
+          stateEmitter.emit('update', packageState());
+        };
+
+        pipelineSteps.forEach(
+          (step) => {
+            step.stateEmitter.on('update', () => stateEmitter.emit('update', packageState()));
+          }
+        );
+
         const loadCache = (output, step) => {
           if (cache[step]) {
             for (let [key] of Object.entries(cache[step])) { // eslint-disable-line no-restricted-syntax, max-len, prefer-const
@@ -55,7 +82,7 @@ module.exports = {
           return output;
         };
         return pipelineSteps.reduce((prom, step, index) => {
-          this.currentStep = index;
+          setStateProp('currentStep', index);
           return prom.then(() => step.start(this.mode === 'remote' ? {} : loadInput(step), remoteHandler))
           .then((output) => {
             loadCache(output, index);

--- a/packages/coinstac-simulator/bin/coinstac-simulator
+++ b/packages/coinstac-simulator/bin/coinstac-simulator
@@ -11,6 +11,8 @@ const sim = require('../src/');
 const inquirer = require('inquirer');
 const glob = util.promisify(require('glob'));
 const path = require('path');
+const blessed = require('blessed');
+const bc = require('blessed-contrib');
 
 const pipeSpec = {
   steps: [
@@ -21,6 +23,27 @@ const pipeSpec = {
     },
   ],
 };
+
+const screen = blessed.screen({
+  smartCSR: true,
+});
+
+const tableData = [];
+
+const table = bc.table({
+  keys: true,
+  fg: 'white',
+  selectedFg: 'white',
+  selectedBg: 'blue',
+  interactive: true,
+  label: 'Active Run',
+  width: '100%',
+  height: '100%',
+  border: { type: 'line', fg: 'cyan' },
+  columnSpacing: 5,
+  columnWidth: [12, 12, 30, 6],
+});
+
 program
   .version(pkg.version)
   .option('-i, --inputspec [path]', '/path/to/inputSpec, defaults to ./test/inputspec.json, will interactively create one if none found')
@@ -113,16 +136,69 @@ readFile(program.compspec ? program.compspec : 'compspec.json')
   });
 })
 .then((pipelineSpec) => {
-  console.log(`Starting ${mode} simulator run with ${program.clientNumber ? program.clientNumber : 1} client(s)`); // eslint-disable-line no-console
-  return sim.startRun({
+  /* eslint-disable no-console */
+  console.log(`Starting ${mode} simulator run with ${program.clientNumber ? program.clientNumber : 1} client(s)`);
+  const simRun = sim.startRun({
     spec: pipelineSpec,
     runMode: mode,
     clientCount: program.clientNumber,
     operatingDirectory: program.directory,
   });
+
+  const updateTable = (node, data) => {
+    let foundNode = false;
+    let state = data.controllerState ? data.controllerState : 'initilizing';
+    state = state === 'stopped' ? 'shutting down docker...' : state;
+
+    tableData.forEach((row, index) => {
+      if (row[0] === node) {
+        tableData[index] = [
+          node,
+          data.currentIteration ? data.currentIteration : 'initilizing',
+          state,
+          data.mode,
+        ];
+        foundNode = true;
+      }
+    });
+    if (!foundNode) {
+      tableData.push([
+        node,
+        data.currentIteration ? data.currentIteration : 'initilizing',
+        state,
+        data.mode,
+      ]);
+    }
+
+    table.setData({
+      headers: ['node', 'iteration', 'state', 'mode'],
+      data: tableData,
+    });
+    screen.render();
+  };
+
+  if (simRun.pipelines.remote) {
+    simRun.pipelines.remote.manager.getPipelineStateListener('simulatorRun')
+    .on('update', (data) => {
+      updateTable('remote', data);
+    });
+  }
+  simRun.pipelines.locals.forEach((local, index) => {
+    local.manager.getPipelineStateListener('simulatorRun').on('update', (data) => {
+      updateTable(`local-${index}`, data);
+    });
+  });
+
+  screen.key(['escape', 'q', 'C-c'], () => process.exit(0));
+  table.focus();
+
+  screen.append(table);
+  screen.render();
+
+  return simRun.allResults;
 })
 .then((results) => {
-  /* eslint-disable no-console */
+  screen.destroy();
   console.log('Simulator run finished');
   if (mode === 'decentralized') {
     console.log(`Decentralized results:\n ${JSON.stringify(results.remote, null, 2)}`);
@@ -133,5 +209,10 @@ readFile(program.compspec ? program.compspec : 'compspec.json')
   // TODO: should not be necessary, something is holding the loop up
   process.exit();
 })
-.catch(err => console.log(`Simulator run failed!\n ${err}`));
+.catch((err) => {
+  screen.destroy();
+  console.log(`Simulator run failed!\n ${err.message}`);
+  console.log(`Fun error details:\n ${err.stack}`);
+  process.exit(1);
+});
 /* eslint-enable no-console */

--- a/packages/coinstac-simulator/package-lock.json
+++ b/packages/coinstac-simulator/package-lock.json
@@ -2,6 +2,22 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
+      }
+    },
     "ansi-escapes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
@@ -17,10 +33,92 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
+    "ansi-term": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/ansi-term/-/ansi-term-0.0.2.tgz",
+      "integrity": "sha1-/XU++kvq2g6smZgbxSo/b/AZ3rc=",
+      "requires": {
+        "x256": "0.0.2"
+      }
+    },
+    "ansicolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
+      "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "blessed": {
+      "version": "0.1.81",
+      "resolved": "https://registry.npmjs.org/blessed/-/blessed-0.1.81.tgz",
+      "integrity": "sha1-+WLWh+wsNpVwrnGvhDJW5tDKESk="
+    },
+    "blessed-contrib": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/blessed-contrib/-/blessed-contrib-4.8.5.tgz",
+      "integrity": "sha1-OXlnF8f+Pky0sHTNyK4vkoDpf/g=",
+      "requires": {
+        "ansi-term": "0.0.2",
+        "chalk": "1.1.3",
+        "drawille-canvas-blessed-contrib": "0.1.3",
+        "lodash": "4.17.5",
+        "map-canvas": "0.1.5",
+        "marked": "0.3.16",
+        "marked-terminal": "1.7.0",
+        "memory-streams": "0.1.3",
+        "memorystream": "0.3.1",
+        "picture-tube": "0.0.4",
+        "request": "2.83.0",
+        "sparkline": "0.1.2",
+        "strip-ansi": "3.0.1",
+        "term-canvas": "0.0.5",
+        "x256": "0.0.2"
+      }
+    },
+    "boom": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "requires": {
+        "hoek": "4.2.1"
+      }
     },
     "brace-expansion": {
       "version": "1.1.8",
@@ -30,6 +128,30 @@
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "bresenham": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/bresenham/-/bresenham-0.0.3.tgz",
+      "integrity": "sha1-q9q55bGU4nx1fNMU2ERDFPKZh3o="
+    },
+    "buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
+    },
+    "cardinal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
+      "integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=",
+      "requires": {
+        "ansicolors": "0.2.1",
+        "redeyed": "1.0.1"
+      }
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
       "version": "1.1.3",
@@ -48,6 +170,11 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
     },
+    "charm": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
+      "integrity": "sha1-BsIe7RobBq62dVPNxT4jJ0usIpY="
+    },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -56,10 +183,23 @@
         "restore-cursor": "2.0.0"
       }
     },
+    "cli-table": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+      "requires": {
+        "colors": "1.0.3"
+      }
+    },
     "cli-width": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "color-convert": {
       "version": "1.9.1",
@@ -73,6 +213,19 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+    },
+    "combined-stream": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
     },
     "commander": {
       "version": "2.13.0",
@@ -165,10 +318,100 @@
         }
       }
     },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cryptiles": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "requires": {
+        "boom": "5.2.0"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "requires": {
+            "hoek": "4.2.1"
+          }
+        }
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "drawille-blessed-contrib": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/drawille-blessed-contrib/-/drawille-blessed-contrib-1.0.0.tgz",
+      "integrity": "sha1-FcJ5NPV6AFatE1luFWFje8lB8Lc="
+    },
+    "drawille-canvas-blessed-contrib": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/drawille-canvas-blessed-contrib/-/drawille-canvas-blessed-contrib-0.1.3.tgz",
+      "integrity": "sha1-IS8HinIr/S7MJn6oarbd3BCB/Ug=",
+      "requires": {
+        "ansi-term": "0.0.2",
+        "bresenham": "0.0.3",
+        "drawille-blessed-contrib": "1.0.0",
+        "gl-matrix": "2.4.0",
+        "x256": "0.0.2"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "esprima": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.0.0.tgz",
+      "integrity": "sha1-U88kes2ncxPlUcOqLnM0LT+099k="
+    },
+    "event-stream": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-0.9.8.tgz",
+      "integrity": "sha1-XanPPHkAl1mJ21powo5bPJjr4Do=",
+      "requires": {
+        "optimist": "0.2.8"
+      },
+      "dependencies": {
+        "optimist": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.2.8.tgz",
+          "integrity": "sha1-6YGrfiaLRXlIWTtVZ0wJmoFcrDE=",
+          "requires": {
+            "wordwrap": "0.0.3"
+          }
+        }
+      }
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "external-editor": {
       "version": "2.1.0",
@@ -180,6 +423,21 @@
         "tmp": "0.0.33"
       }
     },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -188,10 +446,38 @@
         "escape-string-regexp": "1.0.5"
       }
     },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.18"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "gl-matrix": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-2.4.0.tgz",
+      "integrity": "sha1-IImxMwGinuyCLZ2Z3/wfeO6aPFA="
     },
     "glob": {
       "version": "7.1.2",
@@ -206,6 +492,20 @@
         "path-is-absolute": "1.0.1"
       }
     },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "requires": {
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
+      }
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -218,6 +518,37 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
       "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+    },
+    "hawk": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "requires": {
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.1",
+        "sntp": "2.1.0"
+      }
+    },
+    "here": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/here/-/here-0.0.2.tgz",
+      "integrity": "sha1-acGvPwISHz2HiOAuhNyLOQXXEZU="
+    },
+    "hoek": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
+      }
     },
     "iconv-lite": {
       "version": "0.4.19",
@@ -309,10 +640,119 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
     "lodash": {
       "version": "4.17.5",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+    },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+    },
+    "lodash.toarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
+    },
+    "map-canvas": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/map-canvas/-/map-canvas-0.1.5.tgz",
+      "integrity": "sha1-i+a63gvz6fmotW6INqHR0TPKsYY=",
+      "requires": {
+        "drawille-canvas-blessed-contrib": "0.1.3",
+        "xml2js": "0.4.19"
+      }
+    },
+    "marked": {
+      "version": "0.3.16",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.16.tgz",
+      "integrity": "sha512-diLiAxHidES67uJ1P5unXBUB4CyOFwodKrctuK0U4Ogw865N9Aw4dLmY0BK0tGKOy3xvkdMGgUXPD6W9z1Ne0Q=="
+    },
+    "marked-terminal": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-1.7.0.tgz",
+      "integrity": "sha1-yMRgiBx3LHYEtkNnAH7l938SWQQ=",
+      "requires": {
+        "cardinal": "1.0.0",
+        "chalk": "1.1.3",
+        "cli-table": "0.3.1",
+        "lodash.assign": "4.2.0",
+        "node-emoji": "1.8.1"
+      }
+    },
+    "memory-streams": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/memory-streams/-/memory-streams-0.1.3.tgz",
+      "integrity": "sha512-qVQ/CjkMyMInPaaRMrwWNDvf6boRZXaT/DbQeMYcCWuXPEBf1v8qChOc9OlEVQp2uOvRXa1Qu30fLmKhY6NipA==",
+      "requires": {
+        "readable-stream": "1.0.34"
+      }
+    },
+    "memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI="
+    },
+    "mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+    },
+    "mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "requires": {
+        "mime-db": "1.33.0"
+      }
     },
     "mimic-fn": {
       "version": "1.2.0",
@@ -331,6 +771,22 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+    },
+    "node-emoji": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz",
+      "integrity": "sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==",
+      "requires": {
+        "lodash.toarray": "4.4.0"
+      }
+    },
+    "nopt": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
+      "integrity": "sha1-bMzZd7gBMqB3MdbozljCyDA8+a8=",
+      "requires": {
+        "abbrev": "1.1.1"
+      }
     },
     "nyc": {
       "version": "8.4.0",
@@ -1525,6 +1981,11 @@
         }
       }
     },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1541,6 +2002,14 @@
         "mimic-fn": "1.2.0"
       }
     },
+    "optimist": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+      "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+      "requires": {
+        "wordwrap": "0.0.3"
+      }
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -1550,6 +2019,95 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "picture-tube": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/picture-tube/-/picture-tube-0.0.4.tgz",
+      "integrity": "sha1-Id4Ctxecy3OvCD8RL1JnYy/G6MY=",
+      "requires": {
+        "buffers": "0.1.1",
+        "charm": "0.1.2",
+        "event-stream": "0.9.8",
+        "optimist": "0.3.7",
+        "png-js": "0.1.1",
+        "request": "2.9.203",
+        "x256": "0.0.2"
+      },
+      "dependencies": {
+        "request": {
+          "version": "2.9.203",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.9.203.tgz",
+          "integrity": "sha1-bBcRpUB/uUoRQhlWPkQUW8v0cjo="
+        }
+      }
+    },
+    "png-js": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-0.1.1.tgz",
+      "integrity": "sha1-HMfCEjA6yr50Jj7DrHgAlYAkLZM="
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "qs": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+    },
+    "readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "0.0.1",
+        "string_decoder": "0.10.31"
+      }
+    },
+    "redeyed": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz",
+      "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
+      "requires": {
+        "esprima": "3.0.0"
+      }
+    },
+    "request": {
+      "version": "2.83.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.2.1"
+      }
     },
     "restore-cursor": {
       "version": "2.0.0",
@@ -1576,10 +2134,52 @@
         "symbol-observable": "1.0.1"
       }
     },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "sntp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "requires": {
+        "hoek": "4.2.1"
+      }
+    },
+    "sparkline": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/sparkline/-/sparkline-0.1.2.tgz",
+      "integrity": "sha1-w73kYlKxNU5xDEsgDVSBa9nwejI=",
+      "requires": {
+        "here": "0.0.2",
+        "nopt": "2.1.2"
+      }
+    },
+    "sshpk": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      }
     },
     "string-width": {
       "version": "2.1.1",
@@ -1605,6 +2205,16 @@
         }
       }
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+    },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -1623,6 +2233,11 @@
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
       "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
     },
+    "term-canvas": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/term-canvas/-/term-canvas-0.0.5.tgz",
+      "integrity": "sha1-WXr6wvpjaabxeGC86cX2bW6gypY="
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -1636,10 +2251,71 @@
         "os-tmpdir": "1.0.2"
       }
     },
+    "tough-cookie": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
+    },
+    "uuid": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      }
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "x256": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/x256/-/x256-0.0.2.tgz",
+      "integrity": "sha1-ya8Yh296F1gB1WT+cK2egxd4STQ="
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.7"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     }
   }
 }

--- a/packages/coinstac-simulator/package.json
+++ b/packages/coinstac-simulator/package.json
@@ -34,6 +34,8 @@
   },
   "homepage": "https://github.com/MRN-Code/coinstac#readme",
   "dependencies": {
+    "blessed": "^0.1.81",
+    "blessed-contrib": "^4.8.5",
     "chalk": "^1.1.3",
     "coinstac-pipeline": "^3.0.4",
     "commander": "^2.13.0",

--- a/packages/coinstac-simulator/src/index.js
+++ b/packages/coinstac-simulator/src/index.js
@@ -48,7 +48,7 @@ const startRun = ({ spec, runMode = 'local', clientCount = 1, operatingDirectory
     });
   }
 
-  return Promise.all(Object.keys(pipelines).map((key) => {
+  const allResults = Promise.all(Object.keys(pipelines).map((key) => {
     if (key === 'locals') {
       return Promise.all(pipelines[key].map(
         (localP, index) => localP.pipeline.result
@@ -64,6 +64,8 @@ const startRun = ({ spec, runMode = 'local', clientCount = 1, operatingDirectory
     }
     return { locals: pipelines.locals.map(local => local.pipeline.result) };
   });
+
+  return { pipelines, allResults };
 };
 module.exports = {
   startRun,

--- a/packages/coinstac-ui/package-lock.json
+++ b/packages/coinstac-ui/package-lock.json
@@ -4765,13 +4765,6 @@
 						}
 					}
 				},
-				"string_decoder": {
-					"version": "1.0.1",
-					"bundled": true,
-					"requires": {
-						"safe-buffer": "5.0.1"
-					}
-				},
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
@@ -4779,6 +4772,13 @@
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
 						"strip-ansi": "3.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"safe-buffer": "5.0.1"
 					}
 				},
 				"stringstream": {
@@ -11933,14 +11933,6 @@
 			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
 			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
 		},
-		"string_decoder": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-			"requires": {
-				"safe-buffer": "5.1.1"
-			}
-		},
 		"string-width": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -11959,6 +11951,14 @@
 				"define-properties": "1.1.2",
 				"es-abstract": "1.10.0",
 				"function-bind": "1.1.1"
+			}
+		},
+		"string_decoder": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"requires": {
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"stringstream": {


### PR DESCRIPTION
# Problem
referenced issue(s): closes #403, #395

The pipeline didnt expose any way to get what its current state is, making inspecting and troubleshooting difficult to consumers.

# Solution
Expose an emitter, this emitter gives limited but useful state information. Sim now consumes this emitter's info and displays it via a Blessed table
# Testing
Easiest to test w/ sim:
`cd coinstac-simulator/test/test-comps/coinstac-decentralized-test/ && ../../../bin/coinstac-simulator -c 5`
