### PR TITLE
UI: Snackbar on Consortia Save, Computation Creation, and Collection Save

### DIFF
--- a/packages/coinstac-ui/app/render/components/app.jsx
+++ b/packages/coinstac-ui/app/render/components/app.jsx
@@ -4,6 +4,20 @@ import { connect } from 'react-redux';
 import Notifications from 'react-notification-system-redux';
 import { autoLogin } from '../state/ducks/auth';
 
+const styles = {
+  notifications: {
+    NotificationItem: {
+      DefaultStyle: {
+        borderRadius: 0,
+        border: 'none',
+        opacity: 0.75,
+        boxShadow: 'none',
+        fontWeight: 'bold', // This might not be necessary. Use your judgement.
+      },
+    }
+  }
+};
+
 class App extends Component { // eslint-disable-line react/prefer-stateless-function
   constructor(props) {
     super(props);
@@ -34,6 +48,7 @@ class App extends Component { // eslint-disable-line react/prefer-stateless-func
 
         <Notifications
           notifications={notifications}
+          style={styles.notifications}
         />
       </div>
     );

--- a/packages/coinstac-ui/app/render/components/collections/collection-tabs.jsx
+++ b/packages/coinstac-ui/app/render/components/collections/collection-tabs.jsx
@@ -8,7 +8,7 @@ import CollectionFiles from './collection-files';
 import CollectionConsortia from './collection-consortia';
 import { getAssociatedConsortia, getCollectionFiles, incrementRunCount, saveAssociatedConsortia, saveCollection } from '../../state/ducks/collections';
 import { getRunsForConsortium, saveLocalRun } from '../../state/ducks/runs';
-import { notifyInfo } from '../../state/ducks/notifyAndLog';
+import { notifyInfo, notifySuccess } from '../../state/ducks/notifyAndLog';
 
 const styles = {
   tab: {
@@ -50,6 +50,9 @@ class CollectionTabs extends Component {
     }
 
     this.props.saveCollection(this.state.collection);
+    this.props.notifySuccess({
+      message: `Collection Saved.`
+    });
   }
 
   updateAssociatedConsortia(cons) {
@@ -178,6 +181,7 @@ CollectionTabs.propTypes = {
   getRunsForConsortium: PropTypes.func.isRequired,
   incrementRunCount: PropTypes.func.isRequired,
   notifyInfo: PropTypes.func.isRequired,
+  notifySuccess: PropTypes.func.isRequired,
   params: PropTypes.object.isRequired,
   router: PropTypes.object.isRequired,
   saveAssociatedConsortia: PropTypes.func.isRequired,
@@ -196,6 +200,7 @@ export default connect(mapStateToProps,
     getRunsForConsortium,
     incrementRunCount,
     notifyInfo,
+    notifySuccess,
     saveAssociatedConsortia,
     saveCollection,
     saveLocalRun,

--- a/packages/coinstac-ui/app/render/components/computations/computation-submission.jsx
+++ b/packages/coinstac-ui/app/render/components/computations/computation-submission.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { graphql } from 'react-apollo';
+import { compose, graphql, withApollo } from 'react-apollo';
 import {
   Alert,
   Button,
@@ -11,6 +12,7 @@ import {
   ADD_COMPUTATION_MUTATION,
 } from '../../state/graphql/functions';
 import { saveDocumentProp } from '../../state/graphql/props';
+import { notifySuccess } from '../../state/ducks/notifyAndLog';
 
 const styles = {
   topMargin: { marginTop: 10 },
@@ -47,6 +49,11 @@ class ComputationSubmission extends Component { // eslint-disable-line
       this.setState({ activeSchema: {} });
       if (res.data.addComputation) {
         this.setState({ submissionSuccess: true });
+        this.props.router.push('/dashboard/computations');
+        this.props.notifySuccess({
+          message: 'Computation Submission Successful',
+          autoDismiss: 5,
+        });
       } else {
         this.setState({ submissionSuccess: false });
       }
@@ -94,12 +101,6 @@ class ComputationSubmission extends Component { // eslint-disable-line
           </Alert>)
         }
 
-        {!this.state.activeSchema.meta && this.state.submissionSuccess &&
-          <Alert bsStyle="success" style={styles.topMargin}>
-            <strong>Success!</strong> Try another?
-          </Alert>
-        }
-
         {!this.state.activeSchema.meta && this.state.submissionSuccess === false &&
           <Alert bsStyle="danger" style={styles.topMargin}>
             <strong>Error!</strong> Try again?
@@ -117,7 +118,21 @@ class ComputationSubmission extends Component { // eslint-disable-line
 }
 
 ComputationSubmission.propTypes = {
+  notifySuccess: PropTypes.func.isRequired,
   submitSchema: PropTypes.func.isRequired,
 };
 
-export default graphql(ADD_COMPUTATION_MUTATION, saveDocumentProp('submitSchema', 'computationSchema'))(ComputationSubmission);
+const mapStateToProps = ({ notifySuccess, submitSchema }) => {
+  return { notifySuccess, submitSchema };
+};
+
+const ComputationSubmissionWithAlert = compose(
+graphql(ADD_COMPUTATION_MUTATION, saveDocumentProp('submitSchema', 'computationSchema')),
+withApollo
+)(ComputationSubmission);
+
+export default connect(mapStateToProps,
+  {
+    notifySuccess
+  }
+)(ComputationSubmissionWithAlert);

--- a/packages/coinstac-ui/app/render/components/consortia/consortium-tabs.jsx
+++ b/packages/coinstac-ui/app/render/components/consortia/consortium-tabs.jsx
@@ -22,6 +22,7 @@ import {
   REMOVE_USER_ROLE_MUTATION,
   SAVE_CONSORTIUM_MUTATION,
 } from '../../state/graphql/functions';
+import { notifyInfo, notifyWarning } from '../../state/ducks/notifyAndLog';
 
 const styles = {
   tab: {
@@ -109,6 +110,18 @@ class ConsortiumTabs extends Component {
         consortium: { ...other },
         unsubscribeConsortia,
       });
+
+      this.props.notifyInfo({
+        message: 'Consortium Saved',
+        autoDismiss: 5,
+        action: {
+          label: 'View Consortia List',
+          callback: () => {
+            this.props.router.push('/dashboard/consortia/');
+          },
+        },
+      });
+
     })
     .catch(({ graphQLErrors }) => {
       console.log(graphQLErrors);
@@ -192,6 +205,7 @@ ConsortiumTabs.propTypes = {
   auth: PropTypes.object.isRequired,
   consortia: PropTypes.array,
   leaveConsortium: PropTypes.func.isRequired,
+  notifyInfo: PropTypes.func.isRequired,
   params: PropTypes.object.isRequired,
   pipelines: PropTypes.array.isRequired,
   removeUserRole: PropTypes.func.isRequired,
@@ -222,5 +236,10 @@ const ConsortiumTabsWithData = compose(
 
 export default connect(
   mapStateToProps,
-  { saveAssociatedConsortia, updateUserPerms }
+  {
+    notifyInfo,
+    notifyWarning,
+    saveAssociatedConsortia,
+    updateUserPerms,
+  }
 )(ConsortiumTabsWithData);

--- a/packages/coinstac-ui/app/render/components/consortia/consortium-tabs.jsx
+++ b/packages/coinstac-ui/app/render/components/consortia/consortium-tabs.jsx
@@ -22,7 +22,7 @@ import {
   REMOVE_USER_ROLE_MUTATION,
   SAVE_CONSORTIUM_MUTATION,
 } from '../../state/graphql/functions';
-import { notifyInfo, notifyWarning } from '../../state/ducks/notifyAndLog';
+import { notifySuccess } from '../../state/ducks/notifyAndLog';
 
 const styles = {
   tab: {
@@ -111,7 +111,7 @@ class ConsortiumTabs extends Component {
         unsubscribeConsortia,
       });
 
-      this.props.notifyInfo({
+      this.props.notifySuccess({
         message: 'Consortium Saved',
         autoDismiss: 5,
         action: {
@@ -205,7 +205,7 @@ ConsortiumTabs.propTypes = {
   auth: PropTypes.object.isRequired,
   consortia: PropTypes.array,
   leaveConsortium: PropTypes.func.isRequired,
-  notifyInfo: PropTypes.func.isRequired,
+  notifySuccess: PropTypes.func.isRequired,
   params: PropTypes.object.isRequired,
   pipelines: PropTypes.array.isRequired,
   removeUserRole: PropTypes.func.isRequired,
@@ -237,8 +237,7 @@ const ConsortiumTabsWithData = compose(
 export default connect(
   mapStateToProps,
   {
-    notifyInfo,
-    notifyWarning,
+    notifySuccess,
     saveAssociatedConsortia,
     updateUserPerms,
   }

--- a/packages/coinstac-ui/app/render/components/pipelines/pipeline.jsx
+++ b/packages/coinstac-ui/app/render/components/pipelines/pipeline.jsx
@@ -35,6 +35,7 @@ import {
   getDocumentByParam,
   saveDocumentProp,
 } from '../../state/graphql/props';
+import { notifySuccess } from '../../state/ducks/notifyAndLog';
 
 const computationTarget = {
   drop() {
@@ -382,6 +383,10 @@ class Pipeline extends Component {
         pipeline,
         startingPipeline: pipeline,
       });
+
+      this.props.notifySuccess({
+        message: `Pipeline Saved.`
+      });
     })
     .catch(console.log);
   }
@@ -576,6 +581,7 @@ Pipeline.propTypes = {
   computations: PropTypes.array.isRequired,
   connectDropTarget: PropTypes.func.isRequired,
   consortia: PropTypes.array.isRequired,
+  notifySuccess: PropTypes.func.isRequired,
   params: PropTypes.object.isRequired,
   runs: PropTypes.array,
   savePipeline: PropTypes.func.isRequired,
@@ -594,9 +600,11 @@ const PipelineWithData = compose(
   graphql(SAVE_PIPELINE_MUTATION, saveDocumentProp('savePipeline', 'pipeline'))
 )(Pipeline);
 
-export default compose(
+const PipelineWithAlert = compose(
   connect(mapStateToProps),
   DragDropContext(HTML5Backend),
   DropTarget(ItemTypes.COMPUTATION, computationTarget, collect),
   withApollo
 )(PipelineWithData);
+
+export default connect(mapStateToProps,{ notifySuccess })(PipelineWithAlert);

--- a/packages/coinstac-ui/app/render/styles/alert.scss
+++ b/packages/coinstac-ui/app/render/styles/alert.scss
@@ -16,16 +16,3 @@
     border: none;
   }
 }
-
-/**
- * Notifications.
- *
- * Override react-notification-system-redux component styles.
- */
-
-.notification {
-  border-radius: 0 !important;
-  border: none !important;
-  opacity: 0.75 !important;
-  box-shadow: none !important;
-}

--- a/packages/coinstac-ui/app/render/styles/alert.scss
+++ b/packages/coinstac-ui/app/render/styles/alert.scss
@@ -17,3 +17,15 @@
   }
 }
 
+/**
+ * Notifications.
+ *
+ * Override react-notification-system-redux component styles.
+ */
+
+.notification {
+  border-radius: 0 !important;
+  border: none !important;
+  opacity: 0.75 !important;
+  box-shadow: none !important;
+}


### PR DESCRIPTION
# Problem

- Notification appearance is a bit lame.
- There isn't any feedback on saving consortia or pipelines or collections.
- Closes #420

# Solution

- Update the look of all notifications to look more similar to Material style snackbars using the current library react-notification-system-redux. Keep the location in the upper-right-hand corner for now. 
- Call existing notification functions (packages/coinstac-ui/app/render/state/ducks/notifyAndLog.js) on save of consortia, pipelines, and collections.

# Testing

- Create a Consortium
- Create a Computation
- Create a File Collection > Save under About Tab