### PR TITLE
Docker: revise server to use tornado async and stdin streaming

### DIFF
--- a/packages/coinstac-images/coinstac-python-base/requirements.txt
+++ b/packages/coinstac-images/coinstac-python-base/requirements.txt
@@ -1,2 +1,1 @@
-bottle==0.12.13
-gevent==1.2.2
+tornado==5.0.2


### PR DESCRIPTION
# Problem
referenced issue(s):
closes #473 

Docker boxes were hanging :-(
# Solution
The solution is two pronged:
* Reads from `stdout` in python were blocking, even with non-blocking sockets set. This was due to the pipe buffer filling up and gumming up erryting. This could of been fixed via `popen.communicate` but I took the time to rewrite the `bottle` server to a more performant and node-like `tornado` which allowed the next fix to be a bit easier as well...
* Next issue was the large argument size going over the Docker *nix `MAX_ARG_LEN` which is 13k~ish bytes. The solution is to stream the data in over `stdin` which should of probably have been done in the first place.... Fortunately this is a simple fix for computation authors.
# Testing
Running the new branch of `ssr_test_vbm` on coinstac-simulator should test this