### PR TITLE
MSR and DRNE Freesurfer Algs Added

### DIFF
--- a/packages/coinstac-api-server/test/data/drne_fsl_schema.json
+++ b/packages/coinstac-api-server/test/data/drne_fsl_schema.json
@@ -1,20 +1,20 @@
 {
   "meta": {
-    "name": "MSR FreeSurfer",
+    "name": "DRNE FreeSurfer",
     "version": "v1.0.0",
-    "repository": "https:\/\/github.com\/MRN-Code\/coinstac_msr_fsl",
-    "description": "Multi-shot Regression on FreeSurfer Data"
+    "repository": "https:\/\/github.com\/MRN-Code\/coinstac_drne_fsl",
+    "description": "Decentralized Regression with Normal Equation on FreeSurfer Data"
   },
   "computation": {
     "type": "docker",
-    "dockerImage": "msr_fsl",
+    "dockerImage": "drne_fsl",
     "command": [
       "python",
       "\/computation\/local.py"
     ],
     "remote": {
       "type": "docker",
-      "dockerImage": "msr_fsl",
+      "dockerImage": "drne_fsl",
       "command": [
         "python",
         "\/computation\/remote.py"

--- a/packages/coinstac-api-server/test/data/ssr_vbm_mcic-schema.json
+++ b/packages/coinstac-api-server/test/data/ssr_vbm_mcic-schema.json
@@ -1,20 +1,20 @@
 {
   "meta": {
-    "name": "MSR FreeSurfer",
+    "name": "Single Shot Regression VBM MCIC",
     "version": "v1.0.0",
     "repository": "https:\/\/github.com\/MRN-Code\/ssr_test",
-    "description": "Multi-shot Regression on FreeSurfer Data"
+    "description": "Single Shot Regression with Data from Multiple Sites"
   },
   "computation": {
     "type": "docker",
-    "dockerImage": "msr_fsl",
+    "dockerImage": "ssr_vbm_mcic",
     "command": [
       "python",
       "\/computation\/local.py"
     ],
     "remote": {
       "type": "docker",
-      "dockerImage": "msr_fsl",
+      "dockerImage": "ssr_vbm_mcic",
       "command": [
         "python",
         "\/computation\/remote.py"
@@ -35,12 +35,12 @@
       {
         "label": "Covariates",
         "type": "array",
-        "items": ["boolean", "number"]
+        "items": ["boolean", "number", "string"]
       },
       "data": {
         "label": "Data",
         "type": "array",
-        "items": ["FreeSurfer"],
+        "items": ["NIfTI"],
         "extensions": [["csv", "txt"]]
       }
     },
@@ -100,10 +100,6 @@
                 "type": "array"
               }
             }
-          },
-          "ROI": {
-            "label": "Region of Interest",
-            "type": "string"
           }
         }
       }
@@ -116,12 +112,10 @@
             "source": "regressions",
             "subtables": [
               {
-                "source": "global_stats",
-                "subtitle": "ROI"
+                "source": "global_stats"
               },
               {
                 "source": "local_stats",
-                "subtitle": "ROI",
                 "subtables": "by-key"
               }
             ]

--- a/packages/coinstac-api-server/test/test-setup.js
+++ b/packages/coinstac-api-server/test/test-setup.js
@@ -360,7 +360,7 @@ helperFunctions.getRethinkConnection()
     id: 'test-cons-1',
     name: 'Test Consortia 1',
     description: 'This consortia is for testing.',
-    owners: ['test'],
+    owners: ['author'],
     members: [],
   }).run(connection))
   .then(() => rethink.table('consortia').insert({

--- a/packages/coinstac-common/src/services/validator/schemas/computation.js
+++ b/packages/coinstac-common/src/services/validator/schemas/computation.js
@@ -15,6 +15,8 @@ module.exports = {
         .items(Joi.string().required())
         .min(1)
         .required(),
+      display: Joi.array()
+        .items(Joi.object()).required(),
       dockerImage: Joi.string().required(),
       input: Joi.any().required(),
       output: Joi.any().required(),

--- a/packages/coinstac-ui/app/main/index.js
+++ b/packages/coinstac-ui/app/main/index.js
@@ -232,7 +232,7 @@ loadConfig()
       filters = [
         {
           name: 'Images',
-          extensions: ['jpeg', 'jpg', 'png'],
+          extensions: ['jpeg', 'jpg', 'png', 'nii'],
         },
         {
           name: 'Files',

--- a/packages/coinstac-ui/app/render/components/collections/collection-pipeline-input.jsx
+++ b/packages/coinstac-ui/app/render/components/collections/collection-pipeline-input.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import update from 'immutability-helper';
+import inputDataTypes from '../../state/input-data-types';
 
 class CollectionPipelineInput extends Component {
   static getUserPropKey(val) {
@@ -163,7 +164,7 @@ class CollectionPipelineInput extends Component {
                         .computation.output[val.fromCache.variable].type
                 }
                 <br />
-                {val.source === 'file' || val.type === 'FreeSurfer' ?
+                {val.source === 'file' || inputDataTypes.indexOf(val.type) > -1 ?
                     (
                       <span>
                         <em>Source Group: </em>

--- a/packages/coinstac-ui/app/render/components/pipelines/pipeline.jsx
+++ b/packages/coinstac-ui/app/render/components/pipelines/pipeline.jsx
@@ -459,7 +459,6 @@ class Pipeline extends Component {
                 bsStyle="success"
                 className="pull-right"
                 disabled={!this.state.owner || !this.state.pipeline.name.length ||
-                  !this.state.pipeline.description.length ||
                   !consortium}
                 onClick={this.savePipeline}
               >

--- a/packages/coinstac-ui/app/render/components/results/result.jsx
+++ b/packages/coinstac-ui/app/render/components/results/result.jsx
@@ -72,11 +72,11 @@ class Result extends Component {
     const consortium = consortia.find(c => c.id === run.consortiumId);
     let stepsLength = -1;
     let covariates = [];
-    if (run.pipelineSnapshot) {
+    if (run && run.pipelineSnapshot) {
       stepsLength = run.pipelineSnapshot.steps.length;
     }
 
-    if (stepsLength > 0 && run.pipelineSnapshot.steps[stepsLength - 1].inputMap) {
+    if (stepsLength > 0 && run.pipelineSnapshot.steps[stepsLength - 1].inputMap && run.pipelineSnapshot.steps[stepsLength - 1].inputMap.covariates) {
       covariates = run.pipelineSnapshot.steps[stepsLength - 1]
         .inputMap.covariates.ownerMappings.map(m => m.name);
     }
@@ -158,7 +158,7 @@ class Result extends Component {
 
         {run && run.error &&
           <Well style={{ color: 'red' }}>
-            {JSON.stringify(run.error.error.error, null, 2)}
+            {JSON.stringify(run.error.error, null, 2)}
           </Well>
         }
       </div>

--- a/packages/coinstac-ui/app/render/state/ducks/collections.js
+++ b/packages/coinstac-ui/app/render/state/ducks/collections.js
@@ -123,7 +123,7 @@ function iteratePipelineSteps(consortium, filesByGroup, baseDirectory) {
             keyArray[0] = keyArray[0].concat(filepaths).filter(Boolean);
             keyArray[1].push(mappingObj.type);
             if ('value' in mappingObj) {
-              keyArray[1] = keyArray[1].concat(mappingObj.value);
+              keyArray[2] = keyArray[2].concat(mappingObj.value);
             }
           } else if (inputDataTypes.indexOf(mappingObj.type) > -1
               && (!consortium.stepIO[sIndex][key][mappingIndex].groupId

--- a/packages/coinstac-ui/app/render/state/ducks/collections.js
+++ b/packages/coinstac-ui/app/render/state/ducks/collections.js
@@ -2,6 +2,7 @@ import { isEqual } from 'lodash';
 import { dirname, resolve, extname, sep } from 'path';
 import { applyAsyncLoading } from './loading';
 import localDB from '../local-db';
+import inputDataTypes from '../input-data-types.json';
 
 // Actions
 const CLEAR_COLLECTIONS_CONSORTIA = 'CLEAR_COLLECTIONS_CONSORTIA';
@@ -99,7 +100,7 @@ function iteratePipelineSteps(consortium, filesByGroup, baseDirectory) {
               || !consortium.stepIO[sIndex][key][mappingIndex].column)) {
             mappingIncomplete = true;
             break;
-          } else if (filesByGroup && mappingObj.type === 'FreeSurfer'
+          } else if (filesByGroup && inputDataTypes.indexOf(mappingObj.type) > -1
               && consortium.stepIO[sIndex][key][mappingIndex].groupId
               && consortium.stepIO[sIndex][key][mappingIndex].column) {
             let filepaths = filesByGroup[consortium.stepIO[sIndex][key][mappingIndex].groupId];
@@ -120,9 +121,11 @@ function iteratePipelineSteps(consortium, filesByGroup, baseDirectory) {
 
             // There will only ever be one single data object. Don't nest arrays, use concat.
             keyArray[0] = keyArray[0].concat(filepaths).filter(Boolean);
-            keyArray[1] = keyArray[1].concat(mappingObj.value);
-            keyArray[2].push(mappingObj.type);
-          } else if (mappingObj.type === 'FreeSurfer'
+            keyArray[1].push(mappingObj.type);
+            if ('value' in mappingObj) {
+              keyArray[1] = keyArray[1].concat(mappingObj.value);
+            }
+          } else if (inputDataTypes.indexOf(mappingObj.type) > -1
               && (!consortium.stepIO[sIndex][key][mappingIndex].groupId
                 || !consortium.stepIO[sIndex][key][mappingIndex].column)) {
             mappingIncomplete = true;

--- a/packages/coinstac-ui/app/render/state/ducks/runs.js
+++ b/packages/coinstac-ui/app/render/state/ducks/runs.js
@@ -75,13 +75,13 @@ export const saveLocalRun = applyAsyncLoading(run =>
       })
 );
 
-export const updateLocalRun = applyAsyncLoading((runId, objKey, obj) =>
+export const updateLocalRun = applyAsyncLoading((runId, object) =>
   dispatch =>
-    localDB.runs.update(runId, { [objKey]: obj })
+    localDB.runs.update(runId, { ...object })
       .then((key) => {
         dispatch(({
           type: UPDATE_LOCAL_RUN,
-          payload: { runId, objKey, obj },
+          payload: { runId, object },
         }));
         return key;
       })
@@ -143,7 +143,7 @@ export default function reducer(state = INITIAL_STATE, action) {
     case UPDATE_LOCAL_RUN: {
       const localRuns = [...state.localRuns];
       const index = localRuns.findIndex(run => run.id === action.payload.runId);
-      localRuns[index][action.payload.objKey] = action.payload.obj;
+      localRuns[index] = { ...localRuns[index], ...action.payload.object };
 
       return { ...state, localRuns, runs: uniqBy([...localRuns, ...state.remoteRuns].sort(runSort), 'id') };
     }

--- a/packages/coinstac-ui/app/render/state/input-data-types.json
+++ b/packages/coinstac-ui/app/render/state/input-data-types.json
@@ -1,0 +1,3 @@
+[
+  "FreeSurfer", "NIfTI"
+]


### PR DESCRIPTION
# Problem
* Closed #476 
* Errors aren't all structured the same and get displayed incorrectly
* Associated consortia with no stepIO aren't removed when active pipeline changes
# Solution
* Added schema and for freesurfer algs - drne and msr
* Error messages not looking for as nested an error field
* Collection IDs to clear are taken from collections Dexie table and not those listed in a given consortium
# Testing
* `npm run test-setup` in api-server
* Run pipelines featuring msr and drne to see them work