### PR TITLE
fix(coinstac-ui): remove text-decoration from logo

### DIFF
--- a/packages/coinstac-ui/app/render/styles/app.scss
+++ b/packages/coinstac-ui/app/render/styles/app.scss
@@ -54,6 +54,7 @@ $icon-font-path: "~bootstrap-sass/assets/fonts/bootstrap/";
 
     abbr[title] {
         border: none;
+        text-decoration: none;
     }
 }
 


### PR DESCRIPTION
# Problem

There’s an underline on the logo:

![before-logged-out](https://user-images.githubusercontent.com/1858316/39088278-ca26f3c4-4563-11e8-8529-b100114f6efe.jpg)
![before-logged-in](https://user-images.githubusercontent.com/1858316/39088277-c9e72ff0-4563-11e8-9983-aafda7da7008.jpg)

# Solution

The default user agent stylesheet adds `text-underline-*` for `<abbr title="...">...</abbr>`. Add a rule to remove the default style.

# Testing

Boot up the UI on this branch:

![after-logged-out](https://user-images.githubusercontent.com/1858316/39088301-f1523878-4563-11e8-80f2-804037eae310.jpg)
![after-logged-in](https://user-images.githubusercontent.com/1858316/39088302-f1683bf0-4563-11e8-8dd7-d89c6d393ddc.jpg)

🎉 