### PR TITLE
UI: make X and Y, covar and data, from csv use same file names

### DIFF
--- a/packages/coinstac-api-server/test/test-setup.js
+++ b/packages/coinstac-api-server/test/test-setup.js
@@ -24,13 +24,13 @@ helperFunctions.getRethinkConnection()
   .then(() => rethink.tableCreate('computations').run(connection))
   .then(() => rethink.table('computations').insert([
     Object.assign({}, local, { submittedBy: 'test' }),
-    Object.assign({}, localError, { submittedBy: 'test' }),
     Object.assign({}, decentralized, { submittedBy: 'test' }),
-    Object.assign({}, decentralizedError, { submittedBy: 'test' }),
     Object.assign({}, singleShot, { submittedBy: 'test' }),
     Object.assign({}, multiShot, { submittedBy: 'test' }),
     Object.assign({}, vbm, { submittedBy: 'author' }),
     Object.assign({}, drneFsl, { submittedBy: 'author' }),
+    Object.assign({}, decentralizedError, { submittedBy: 'test' }),
+    Object.assign({}, localError, { submittedBy: 'test' }),
   ], { returnChanges: true }).run(connection))
   .then(compInsertResult => rethink.table('pipelines').insert([
     {

--- a/packages/coinstac-pipeline/test/index.test.js
+++ b/packages/coinstac-pipeline/test/index.test.js
@@ -2,7 +2,7 @@ const test = require('ava').test;
 const computationSpecs = require('./computation-specs');
 const path = require('path');
 const PipelineManager = require('../src/pipeline-manager');
-const dockerManager = require('coinstac-docker-manager');
+const DockerManager = require('coinstac-docker-manager');
 const rimraf = require('rimraf-promise');
 
 const localCompSpec = computationSpecs.local;
@@ -94,7 +94,7 @@ let local4;
 
 test.before(() => {
   const proms = [];
-  const docker = new dockerManager.Docker();
+  const docker = new DockerManager.Docker();
   const pullImage = (image) => {
     let proxRej;
     let proxRes;

--- a/packages/coinstac-ui/app/main/index.js
+++ b/packages/coinstac-ui/app/main/index.js
@@ -133,7 +133,15 @@ loadConfig()
           consName: consortium.name,
           run: Object.assign(
             run,
-            { error: { message: error.message, stack: error.stack, error: error.error, input: error.input }, endDate: Date.now() }
+            {
+              error: {
+                message: error.message,
+                stack: error.stack,
+                error: error.error,
+                input: error.input,
+              },
+              endDate: Date.now(),
+            }
           ),
         });
       });


### PR DESCRIPTION
# Problem
referenced issue(s):
Algo authors where having trouble mapping covar file names to docker generated names, and the process was confusing in general
# Solution
Simplify things and make docker names be what everything uses
# Testing
