### PR TITLE
Pipeline: allow users to join early, fixing remote late starting issues

### DIFF
--- a/packages/coinstac-pipeline/package-lock.json
+++ b/packages/coinstac-pipeline/package-lock.json
@@ -1110,6 +1110,7 @@
 			"requires": {
 				"anymatch": "^1.3.0",
 				"async-each": "^1.0.0",
+				"fsevents": "^1.0.0",
 				"glob-parent": "^2.0.0",
 				"inherits": "^2.0.1",
 				"is-binary-path": "^1.0.0",
@@ -1122,6 +1123,14 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
 			"integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA=="
+		},
+		"clarify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/clarify/-/clarify-2.1.0.tgz",
+			"integrity": "sha512-sWdsTozdtoFQbmncCXqCKeUzQbEZul/WJ8xYGVJgfIf4xMEM5q0La+Gjo2MFNOVL0FfTFteHqw6JX+9M71dAdQ==",
+			"requires": {
+				"stack-chain": "^2.0.0"
+			}
 		},
 		"clean-stack": {
 			"version": "1.3.0",
@@ -1760,6 +1769,468 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"fsevents": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+			"optional": true,
+			"requires": {
+				"nan": "^2.9.2",
+				"node-pre-gyp": "^0.10.0"
+			},
+			"dependencies": {
+				"abbrev": {
+					"version": "1.1.1",
+					"bundled": true,
+					"optional": true
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"aproba": {
+					"version": "1.2.0",
+					"bundled": true,
+					"optional": true
+				},
+				"are-we-there-yet": {
+					"version": "1.1.4",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"delegates": "^1.0.0",
+						"readable-stream": "^2.0.6"
+					}
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"bundled": true,
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"chownr": {
+					"version": "1.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true
+				},
+				"console-control-strings": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"debug": {
+					"version": "2.6.9",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"deep-extend": {
+					"version": "0.5.1",
+					"bundled": true,
+					"optional": true
+				},
+				"delegates": {
+					"version": "1.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"detect-libc": {
+					"version": "1.0.3",
+					"bundled": true,
+					"optional": true
+				},
+				"fs-minipass": {
+					"version": "1.2.5",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"minipass": "^2.2.1"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"gauge": {
+					"version": "2.7.4",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"aproba": "^1.0.3",
+						"console-control-strings": "^1.0.0",
+						"has-unicode": "^2.0.0",
+						"object-assign": "^4.1.0",
+						"signal-exit": "^3.0.0",
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wide-align": "^1.1.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.2",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"has-unicode": {
+					"version": "2.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"iconv-lite": {
+					"version": "0.4.21",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"safer-buffer": "^2.1.0"
+					}
+				},
+				"ignore-walk": {
+					"version": "3.0.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"minimatch": "^3.0.4"
+					}
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"once": "^1.3.0",
+						"wrappy": "1"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true
+				},
+				"ini": {
+					"version": "1.3.5",
+					"bundled": true,
+					"optional": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"bundled": true
+				},
+				"minipass": {
+					"version": "2.2.4",
+					"bundled": true,
+					"requires": {
+						"safe-buffer": "^5.1.1",
+						"yallist": "^3.0.0"
+					}
+				},
+				"minizlib": {
+					"version": "1.1.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"minipass": "^2.2.1"
+					}
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"needle": {
+					"version": "2.2.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"debug": "^2.1.2",
+						"iconv-lite": "^0.4.4",
+						"sax": "^1.2.4"
+					}
+				},
+				"node-pre-gyp": {
+					"version": "0.10.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"detect-libc": "^1.0.2",
+						"mkdirp": "^0.5.1",
+						"needle": "^2.2.0",
+						"nopt": "^4.0.1",
+						"npm-packlist": "^1.1.6",
+						"npmlog": "^4.0.2",
+						"rc": "^1.1.7",
+						"rimraf": "^2.6.1",
+						"semver": "^5.3.0",
+						"tar": "^4"
+					}
+				},
+				"nopt": {
+					"version": "4.0.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"abbrev": "1",
+						"osenv": "^0.1.4"
+					}
+				},
+				"npm-bundled": {
+					"version": "1.0.3",
+					"bundled": true,
+					"optional": true
+				},
+				"npm-packlist": {
+					"version": "1.1.10",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"ignore-walk": "^3.0.1",
+						"npm-bundled": "^1.0.1"
+					}
+				},
+				"npmlog": {
+					"version": "4.1.2",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"are-we-there-yet": "~1.1.2",
+						"console-control-strings": "~1.1.0",
+						"gauge": "~2.7.3",
+						"set-blocking": "~2.0.0"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"bundled": true,
+					"optional": true
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"requires": {
+						"wrappy": "1"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"os-tmpdir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"osenv": {
+					"version": "0.1.5",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"os-homedir": "^1.0.0",
+						"os-tmpdir": "^1.0.0"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"process-nextick-args": {
+					"version": "2.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"rc": {
+					"version": "1.2.7",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"deep-extend": "^0.5.1",
+						"ini": "~1.3.0",
+						"minimist": "^1.2.0",
+						"strip-json-comments": "~2.0.1"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "1.2.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"readable-stream": {
+					"version": "2.3.6",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.2",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"glob": "^7.0.5"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.1.1",
+					"bundled": true
+				},
+				"safer-buffer": {
+					"version": "2.1.2",
+					"bundled": true,
+					"optional": true
+				},
+				"sax": {
+					"version": "1.2.4",
+					"bundled": true,
+					"optional": true
+				},
+				"semver": {
+					"version": "5.5.0",
+					"bundled": true,
+					"optional": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"tar": {
+					"version": "4.4.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"chownr": "^1.0.1",
+						"fs-minipass": "^1.2.5",
+						"minipass": "^2.2.4",
+						"minizlib": "^1.1.0",
+						"mkdirp": "^0.5.0",
+						"safe-buffer": "^5.1.1",
+						"yallist": "^3.0.2"
+					}
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"wide-align": {
+					"version": "1.1.2",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"string-width": "^1.0.2"
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"yallist": {
+					"version": "3.0.2",
+					"bundled": true
+				}
+			}
 		},
 		"function-name-support": {
 			"version": "0.2.0",
@@ -2777,6 +3248,12 @@
 				"arrify": "^1.0.0",
 				"minimatch": "^3.0.0"
 			}
+		},
+		"nan": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+			"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+			"optional": true
 		},
 		"negotiator": {
 			"version": "0.6.1",
@@ -6074,6 +6551,11 @@
 				"tweetnacl": "~0.14.0"
 			}
 		},
+		"stack-chain": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-2.0.0.tgz",
+			"integrity": "sha512-GGrHXePi305aW7XQweYZZwiRwR7Js3MWoK/EHzzB9ROdc75nCnjSJVi21rdAGxFl+yCx2L2qdfl5y7NO4lTyqg=="
+		},
 		"stack-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -6290,6 +6772,14 @@
 			"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
 			"requires": {
 				"punycode": "^1.4.1"
+			}
+		},
+		"trace": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/trace/-/trace-3.1.0.tgz",
+			"integrity": "sha512-TM3FY+Kbpz7E81J+AHqA6abcQ9+ExAer2Xw0qFBlPwqPfjooYjJ6KOe+B7Y8lbUc7W7xtRC0aH6lGgrXoo7/Ig==",
+			"requires": {
+				"stack-chain": "^2.0.0"
 			}
 		},
 		"trim-newlines": {

--- a/packages/coinstac-pipeline/package.json
+++ b/packages/coinstac-pipeline/package.json
@@ -27,7 +27,9 @@
   "description": "Computation registry service for COINSTAC.",
   "devDependencies": {
     "ava": "^0.24.0",
-    "rimraf-promise": "^2.0.0"
+    "clarify": "^2.1.0",
+    "rimraf-promise": "^2.0.0",
+    "trace": "^3.1.0"
   },
   "homepage": "https://github.com/MRN-Code/coinstac#readme",
   "keywords": [

--- a/packages/coinstac-pipeline/src/controller.js
+++ b/packages/coinstac-pipeline/src/controller.js
@@ -63,7 +63,6 @@ module.exports = {
        * @return {Promise}                resolves to the final computation output
        */
       start: (input, remoteHandler) => {
-        const queue = [];
         setStateProp('state', 'started');
         controllerState.remoteInitial = controllerState.mode === 'remote' ? true : undefined;
         if (!controllerState.initialized) {
@@ -155,7 +154,6 @@ module.exports = {
               throw new Error('unknown controller runType');
           }
         };
-        queue.push(iterateComp);
 
         /**
          * The trampoline works by continuously bouncing calls on and off the stack
@@ -180,18 +178,21 @@ module.exports = {
          * with the trampoline this allows an unlimited number of steps without stack issues.
          * Credit to Dave's blog: http://www.datchley.name/asynchronous-in-the-browser/
          * @param  {Object}   initialInput the object to pass to computation
-         * @param  {Array}    steps        the dynamic array for the waterfall
          * @param  {Function} done         callback
          * @return {Object}                computation's result
          */
-        const waterfall = (initialInput, steps, done, err) => {
+        const waterfall = (initialInput, done, err) => {
+          const queue = [];
+
           setStateProp('state', 'running');
-          steps.push(done);
+          queue.push(iterateComp);
+          queue.push(done);
+
           trampoline(() => {
-            return steps.length ?
+            return queue.length ?
             function _cb(...args) {
               const argsArray = [].slice.call(args);
-              const fn = steps.shift();
+              const fn = queue.shift();
               controllerState.currentBoxCommand = activeControlBox.preIteration(controllerState);
 
               if ((controllerState.mode === 'local' && controllerState.iteration === 0) ||
@@ -200,10 +201,11 @@ module.exports = {
                 argsArray.unshift(input);
               }
               if (controllerState.currentBoxCommand !== 'done' && controllerState.currentBoxCommand !== 'doneRemote') {
-                const lastCallback = steps.pop();
-                steps.push(iterateComp);
-                steps.push(lastCallback);
+                const lastCallback = queue.pop();
+                queue.push(iterateComp);
+                queue.push(lastCallback);
               }
+
               // necessary if this function call turns out synchronous
               // the stack won't clear and overflow, has limited perf impact
               process.nextTick(() => fn.apply(this, argsArray.concat([_cb, err])));
@@ -220,7 +222,7 @@ module.exports = {
             .then(() => rej(err));
           };
 
-          waterfall(input, queue, (result) => {
+          waterfall(input, (result) => {
             setStateProp('state', 'stopped');
             controllerState.activeComputations[controllerState.computationIndex].stop()
             .then(() => res(result));

--- a/packages/coinstac-pipeline/src/pipeline-manager.js
+++ b/packages/coinstac-pipeline/src/pipeline-manager.js
@@ -42,11 +42,12 @@ module.exports = {
 
     const waitingOnForRun = (runId) => {
       const waiters = [];
-      for (let [key, val] of Object.entries(remoteClients)) { // eslint-disable-line no-restricted-syntax, max-len, prefer-const
-        if (val[runId] && !val[runId].currentOutput) {
-          waiters.push(key);
+      activePipelines[runId].clients.forEach((client) => {
+        if (remoteClients[client][runId] && !remoteClients[client][runId].currentOutput) {
+          waiters.push(client);
         }
-      }
+      });
+
       return waiters;
     };
 
@@ -89,8 +90,24 @@ module.exports = {
         });
 
         socket.on('run', (data) => {
-          console.log(JSON.stringify(data, null, 2));
-          // TODO: probably put in a 'pre-run' route?
+          console.log(JSON.stringify(data, null, 2)); // eslint-disable-line no-console
+          // client run started before remote
+          if (!activePipelines[data.runId]) {
+            activePipelines[data.runId] = {
+              state: 'pre-pipeline',
+              currentState: {},
+            };
+          }
+          if (activePipelines[data.runId].state === 'pre-pipeline' && remoteClients[data.id][data.runId] === undefined) {
+            remoteClients[data.id] = Object.assign(
+              {
+                [data.runId]: {},
+              },
+              remoteClients[data.id]
+            );
+          }
+
+          // normal pipeline operation
           if (remoteClients[data.id] && remoteClients[data.id][data.runId]) {
             socket.join(data.runId);
             remoteClients[data.id].lastSeen = Math.floor(Date.now() / 1000);
@@ -100,26 +117,27 @@ module.exports = {
               // has this pipeline error'd out?
               if (!activePipelines[data.runId].error) {
                 remoteClients[data.id][data.runId].currentOutput = data.output.output;
-                activePipelines[data.runId].state = 'recieved client data';
 
-                const waitingOn = waitingOnForRun(data.runId);
-                activePipelines[data.runId].currentState.waitingOn = waitingOn;
-                activePipelines[data.runId].stateEmitter
-                .emit('update',
-                  Object.assign(
-                    {},
-                    activePipelines[data.runId].pipeline.currentState,
-                    activePipelines[data.runId].currentState
-                  )
-                );
+                if (activePipelines[data.runId].state !== 'pre-pipeline') {
+                  const waitingOn = waitingOnForRun(data.runId);
+                  activePipelines[data.runId].currentState.waitingOn = waitingOn;
+                  activePipelines[data.runId].stateEmitter
+                  .emit('update',
+                    Object.assign(
+                      {},
+                      activePipelines[data.runId].pipeline.currentState,
+                      activePipelines[data.runId].currentState
+                    )
+                  );
 
-                if (waitingOn.length === 0) {
-                  activePipelines[data.runId].state = 'recieved all clients data';
-                  console.log('############ AGG');
-                  const agg = aggregateRun(data.runId);
-                  console.log(JSON.stringify(agg, null, 2))
-                  console.log('############ END AGG');
-                  activePipelines[data.runId].remote.resolve({ output: agg });
+                  if (waitingOn.length === 0) {
+                    activePipelines[data.runId].state = 'recieved all clients data';
+                    console.log('############ AGG'); // eslint-disable-line no-console
+                    const agg = aggregateRun(data.runId);
+                    console.log(JSON.stringify(agg, null, 2)); // eslint-disable-line no-console
+                    console.log('############ END AGG'); // eslint-disable-line no-console
+                    activePipelines[data.runId].remote.resolve({ output: agg });
+                  }
                 }
               } else {
                 io.of('/').to(data.runId).emit('run', { runId: data.runId, error: activePipelines[data.runId].error });
@@ -195,12 +213,19 @@ module.exports = {
        *                               Promise for its result
        */
       startPipeline({ spec, clients = [], runId }) {
-        activePipelines[runId] = {
-          state: 'created',
-          pipeline: Pipeline.create(spec, runId, { mode, operatingDirectory, clientId }),
-          stateEmitter: new Emitter(),
-          currentState: {},
-        };
+        if (activePipelines[runId] && activePipelines[runId].state !== 'pre-pipeline') {
+          throw new Error('Duplicate pipeline started');
+        }
+        activePipelines[runId] = Object.assign(
+          {
+            state: 'created',
+            pipeline: Pipeline.create(spec, runId, { mode, operatingDirectory, clientId }),
+            stateEmitter: new Emitter(),
+            currentState: {},
+            clients,
+          },
+          activePipelines[runId]
+        );
         clients.forEach((client) => {
           remoteClients[client] = Object.assign(
             {
@@ -232,9 +257,9 @@ module.exports = {
               activePipelines[pipeline.id].remote.reject(runError);
               io.of('/').to(pipeline.id).emit('run', { runId: pipeline.id, error: runError });
             } else {
-              console.log('############ REMOTE OUT');
-              console.log(JSON.stringify(message, null, 2))
-              console.log('############ END REMOTE OUT');
+              console.log('############ REMOTE OUT'); // eslint-disable-line no-console
+              console.log(JSON.stringify(message, null, 2)); // eslint-disable-line no-console
+              console.log('############ END REMOTE OUT'); // eslint-disable-line no-console
               io.of('/').to(pipeline.id).emit('run', { runId: pipeline.id, output: message });
             }
           } else {
@@ -254,16 +279,34 @@ module.exports = {
             proxRes = resolve;
             proxRej = reject;
           });
-          activePipelines[runId].state = 'waiting for remote';
           activePipelines[runId].remote = {
             resolve: proxRes,
             reject: proxRej,
           };
           if (!noop) {
+            // only send out results, don't wait
+            // this allows the last remote iteration to just finish
             if (transmitOnly) {
               proxRes();
             }
             communicate(activePipelines[runId].pipeline, input);
+            activePipelines[runId].state = 'running';
+          } else if (activePipelines[runId].state === 'pre-pipeline') {
+            const waitingOn = waitingOnForRun(runId);
+            activePipelines[runId].currentState.waitingOn = waitingOn;
+            activePipelines[runId].stateEmitter
+            .emit('update',
+              Object.assign(
+                {},
+                activePipelines[runId].pipeline.currentState,
+                activePipelines[runId].currentState
+              )
+            );
+
+            if (waitingOn.length === 0) {
+              proxRes({ output: aggregateRun(runId) });
+            }
+            activePipelines[runId].state = 'running';
           }
           return prom;
         };
@@ -277,8 +320,6 @@ module.exports = {
           throw new Error(`Unable to create pipeline directories: ${err}`);
         })
         .then(() => {
-          activePipelines[runId].state = 'running';
-
           this.activePipelines[runId].pipeline.stateEmitter.on('update',
             data => this.activePipelines[runId].stateEmitter
               .emit('update', Object.assign({}, data, activePipelines[runId].currentState)));
@@ -288,6 +329,14 @@ module.exports = {
             activePipelines[runId].state = 'finished';
             return res;
           });
+        }).then((res) => {
+          delete activePipelines[runId];
+          Object.keys(remoteClients).forEach((key) => {
+            if (remoteClients[key][runId]) {
+              delete remoteClients[key][runId];
+            }
+          });
+          return res;
         });
 
         return {

--- a/packages/coinstac-pipeline/src/pipeline.js
+++ b/packages/coinstac-pipeline/src/pipeline.js
@@ -60,7 +60,6 @@ module.exports = {
           this[prop] = val;
           stateEmitter.emit('update', packageState());
         };
-
         pipelineSteps.forEach(
           (step) => {
             step.stateEmitter.on('update', () => stateEmitter.emit('update', packageState()));

--- a/packages/coinstac-pipeline/test/index.test.js
+++ b/packages/coinstac-pipeline/test/index.test.js
@@ -1,3 +1,4 @@
+'use strict';
 
 require('trace');
 require('clarify');

--- a/packages/coinstac-pipeline/test/index.test.js
+++ b/packages/coinstac-pipeline/test/index.test.js
@@ -1,3 +1,6 @@
+
+require('trace');
+require('clarify');
 const test = require('ava').test;
 const computationSpecs = require('./computation-specs');
 const path = require('path');
@@ -9,6 +12,8 @@ const localCompSpec = computationSpecs.local;
 const localErrorCompSpec = computationSpecs.localError;
 const decentralizedCompSpec = computationSpecs.decentralized;
 const decentralizedErrorCompSpec = computationSpecs.decentralizedError;
+Error.stackTraceLimit = Infinity;
+
 
 const localPipelineSpec = {
   steps: [
@@ -49,6 +54,18 @@ const mixedPipelineSpec = {
         start: { value: 2 },
       },
     },
+    {
+      controller: { type: 'decentralized' },
+      computations: [decentralizedCompSpec],
+      inputMap: {
+        start: { value: 1 },
+      },
+    },
+  ],
+};
+
+const decentralizedPipelineSpec = {
+  steps: [
     {
       controller: { type: 'decentralized' },
       computations: [decentralizedCompSpec],
@@ -245,6 +262,76 @@ test('test local error', (t) => {
   return pipeline.result.catch((error) => {
     t.true(error.message.includes('local only throws error'));
   });
+});
+
+test('test pre remote start data preservation', (t) => {
+  const localPipeline = local.startPipeline({
+    spec: decentralizedPipelineSpec,
+    runId: 'prePipe',
+  });
+  const localPipeline2 = local.startPipeline({
+    spec: decentralizedPipelineSpec,
+    runId: 'prePipeMultUser',
+  });
+
+
+  let once = true;
+  let proxRej;
+  let proxRes;
+  const prom = new Promise((resolve, reject) => {
+    proxRes = resolve;
+    proxRej = reject;
+  });
+  let once2 = true;
+  let proxRej2;
+  let proxRes2;
+  const prom2 = new Promise((resolve, reject) => {
+    proxRes2 = resolve;
+    proxRej2 = reject;
+  });
+
+  localPipeline.stateEmitter.on('update', (data) => {
+    // allow time for remote server to get first iteration
+    if (data.controllerState === 'waiting on central node' && once) {
+      setTimeout(() => {
+        once = false;
+        const remotePipeline = remote.startPipeline({
+          clients: ['one'],
+          spec: decentralizedPipelineSpec,
+          runId: 'prePipe',
+        });
+        remotePipeline.result
+        .then((result) => {
+          t.is(result.sum, 5);
+          proxRes(result);
+        }).catch(err => proxRej(err));
+      }, 5000);
+    }
+  });
+  localPipeline2.stateEmitter.on('update', (data) => {
+    // allow time for remote server to get first iteration
+    if (data.controllerState === 'waiting on central node' && once2) {
+      setTimeout(() => {
+        once2 = false;
+        const remotePipeline = remote.startPipeline({
+          clients: ['one', 'two'],
+          spec: decentralizedPipelineSpec,
+          runId: 'prePipeMultUser',
+        });
+        local2.startPipeline({
+          spec: decentralizedPipelineSpec,
+          runId: 'prePipeMultUser',
+        });
+        remotePipeline.result
+        .then((result) => {
+          t.is(result.sum, 5);
+          proxRes2(result);
+        }).catch(err => proxRej2(err));
+      }, 5000);
+    }
+  });
+
+  return Promise.all([prom, prom2]);
 });
 
 test.after.always('cleanup', () => {

--- a/packages/coinstac-server/src/routes/pipeline.js
+++ b/packages/coinstac-server/src/routes/pipeline.js
@@ -83,7 +83,7 @@ module.exports = [
           pullImagesFromList(computationImageList)
           .then(() => pruneImages())
           .then(() => {
-            const { pipeline, result, stateEmitter } = this.remotePipelineManager.startPipeline({
+            const { result, stateEmitter } = this.remotePipelineManager.startPipeline({
               clients: run.clients,
               spec: run.pipelineSnapshot,
               runId: run.id,


### PR DESCRIPTION
# Problem
referenced issue(s):
Closes #549 

If the pipe hasnt called `start` the pipeline will hang
# Solution
This is due to there being no pipeline object to put data to, the solution is allowing temporary pipelines if there is none, waiting for the incoming start call.

# Testing
`npm run test`