### PR TITLE
refactor: move UI artifacts to build directory

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,4 +4,4 @@
 .vscode
 coverage
 node_modules
-packages/coinstac-ui/app/render/build/
+packages/coinstac-ui/build/

--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,7 @@ packages/coinstac-server-core/computations
 jsconfig.json
 
 # Built files
-packages/coinstac-ui/app/render/build
+packages/coinstac-ui/build
 
 # Configuration files
 packages/coinstac-simulator/config/*

--- a/packages/coinstac-ui/.ignore
+++ b/packages/coinstac-ui/.ignore
@@ -1,3 +1,3 @@
-app/render/build/
+build/
 node_modules/
 coverage/

--- a/packages/coinstac-ui/scripts/build.js
+++ b/packages/coinstac-ui/scripts/build.js
@@ -6,11 +6,12 @@ const rm = pify(require('rimraf'));
 const os = require('os');
 const path = require('path');
 
-const platform = ['linux', 'win32', 'darwin'];
+const platform = 'darwin'; // ['linux', 'win32', 'darwin'];
 const options = {
   asar: true,
   dir: `${__dirname}/../`,
   name: 'coinstac',
+  out: path.join(__dirname, '..', 'build', 'apps'),
   overwrite: true,
   prune: true,
 };

--- a/packages/coinstac-ui/scripts/build.js
+++ b/packages/coinstac-ui/scripts/build.js
@@ -6,8 +6,8 @@ const rm = pify(require('rimraf'));
 const os = require('os');
 const path = require('path');
 
-const platform = 'darwin'; // ['linux', 'win32', 'darwin'];
 const options = {
+  all: true,
   asar: true,
   dir: `${__dirname}/../`,
   name: 'coinstac',

--- a/packages/coinstac-ui/webpack.config.js
+++ b/packages/coinstac-ui/webpack.config.js
@@ -102,7 +102,7 @@ const config = {
   output: {
     filename: 'bundle.js',
     libraryTarget: 'commonjs2',
-    path: path.join(__dirname, 'app', 'render', 'build'),
+    path: path.join(__dirname, 'build', 'render'),
     publicPath: './build/',
   },
   plugins: [new webpack.optimize.OccurrenceOrderPlugin()],


### PR DESCRIPTION
# Problem

* Placing the UI's built render file inside _app_ is annoying: it doesn't separate build artifacts from code, makes grep-ing for stuff difficult
* Dumping all the built apps in the _coinstac-ui_ root: same deal

referenced issue(s): _n/a_

# Solution

Move all artifacts/built apps to _packages/coinstac-ui/build_

# Testing

`npm run build`