### PR TITLE
Fixed and Tested issue #589

### DIFF
--- a/packages/coinstac-ui/app/render/components/results/displays/result-table.jsx
+++ b/packages/coinstac-ui/app/render/components/results/displays/result-table.jsx
@@ -56,7 +56,7 @@ function parseTableColumnOutput(output) {
     // eslint-disable-next-line
     output.map((o) => {
       o = parseFloat(o).toFixed(4);
-      if (o === 0) {
+      if (parseFloat(o) === 0) {
         o = 0;
       } else if (Math.abs(o) > 999 || Math.abs(o) < 0.001) {
         o = parseFloat(o).toExponential(4);


### PR DESCRIPTION
# Problem
referenced issue(s): #589 

# Solution

added code to change value to a float if necessary

# Testing

To test change a result value in an existing SSR run from 0 to 1e-10

Example RethinkDB Query: 

`r.db('coinstac').table('runs').get('cf6275db-e1da-47b9-98be-4ff65b143746').update({"results":{"regressions":[{"ROI":"CSF Test","global_stats":{"Coefficient":[-871.4072995272,134.0767727394,-847.6021559564],"Degrees of Freedom":177,"P-value":[0.089566453,1e-10,0.0060924359],"R Squared":0.5599259981,"covariate_labels":["const","age","isControl"],"t Stat":[-1.7070493667,14.8408121085,-2.7761550886]},"local_stats":{"test1":{"Coefficient":[-758.1010064678,125.1100860178,-716.4789525531],"P-value":[0.2593959137,1e-10,0.0745752883],"R Squared":0.5408726844,"Sum Square of Errors":372885064.88676375,"covariate_labels":["const","age","isControl"],"t Stat":[-1.1344635511,10.5936225298,-1.8024817141]},"test2":{"Coefficient":[-984.7135925867,143.0434594609,-978.7253593597],"P-value":[0.213425437,1e-10,0.0424076015],"R Squared":0.5955279287,"Sum Square of Errors":344368369.08141315,"covariate_labels":["const","age","isControl"],"t Stat":[-1.2545818972,10.2716703582,-2.0637825065]}}}]},"startDate":1539632163413,"type":"decentralized"})`