### PR TITLE
Lock apollo-server-hapi version to 1.2.x

### DIFF
--- a/packages/coinstac-api-server/package.json
+++ b/packages/coinstac-api-server/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "apollo-server-hapi": "^1.2.0",
+    "apollo-server-hapi": "1.2.x",
     "axios": "^0.17.1",
     "bluebird": "^3.5.1",
     "boom": "^5.2.0",


### PR DESCRIPTION
# Problem
referenced issue(s):

# Solution

# Testing
