### PR TITLE
UI - dpSVM Revamp + Data and Covariate Labels in Mapping

### DIFF
--- a/packages/coinstac-api-server/test/data/coinstac-dpsvm.json
+++ b/packages/coinstac-api-server/test/data/coinstac-dpsvm.json
@@ -1,27 +1,41 @@
 {
   "meta": {
-    "name": "Differentially Private Support Vector Machines demo",
+    "name": "Differentially Private Support Vector Machines Demo",
     "id": "dpsvm",
     "version": "v1.0.0",
     "repository": "https:\/\/github.com\/MRN-Code\/coinstac_dpSVM",
-    "description": "a test from single shot regresssion"
+    "description": "A test from single shot regresssion"
   },
   "computation": {
     "type": "docker",
     "dockerImage": "coinstacteam/dpsvm",
     "command": [
       "python",
-      "\/computation\/local.py"
+      "\/computation\/scripts\/local.py"
     ],
     "remote": {
       "type": "docker",
       "dockerImage": "coinstacteam/dpsvm",
       "command": [
         "python",
-        "\/computation\/remote.py"
+        "\/computation\/scripts\/remote.py"
       ]
     },
     "input": {
+      "data": {
+        "label": "Features",
+        "type": "array",
+        "items": ["FreeSurfer"],
+        "extensions": [["csv", "txt"]],
+        "order": 0
+      },
+      "covariates":
+      {
+        "label": "Labels",
+        "type": "array",
+        "items": ["boolean", "number"],
+        "order": 1
+      },
       "lambda":
       {
         "default": 0,
@@ -30,13 +44,19 @@
         "min": 0,
         "step": 0.05,
         "type": "number",
-        "source": "owner"
+        "source": "owner",
+        "order": 2
       },
-      "data": {
-        "label": "Data",
-        "type": "bundle",
-        "items": ["Pickle"],
-        "extensions": [["Pickle"]]
+      "train_split":
+      {
+        "default": 0.8,
+        "label": "Train Split",
+        "max": 1,
+        "min": 0,
+        "step": 0.1,
+        "type": "number",
+        "source": "owner",
+        "order": 3
       }
     },
     "output": {
@@ -105,7 +125,23 @@
     },
     "display": [
       {
-        "type": ""
+        "type": "string",
+        "tables": [
+          {
+            "source": "regressions",
+            "subtables": [
+              {
+                "source": "global_stats",
+                "subtitle": "ROI"
+              },
+              {
+                "source": "local_stats",
+                "subtitle": "ROI",
+                "subtables": "by-key"
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/packages/coinstac-ui/app/render/components/maps/maps-pipeline-variables.jsx
+++ b/packages/coinstac-ui/app/render/components/maps/maps-pipeline-variables.jsx
@@ -5,7 +5,6 @@ import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 import { withStyles } from '@material-ui/core/styles';
-import { merge } from 'lodash';
 import MapsStepFieldset from './maps-step-fieldset';
 
 const styles = theme => ({

--- a/packages/coinstac-ui/app/render/components/maps/maps-pipeline-variables.jsx
+++ b/packages/coinstac-ui/app/render/components/maps/maps-pipeline-variables.jsx
@@ -5,6 +5,7 @@ import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 import { withStyles } from '@material-ui/core/styles';
+import { merge } from 'lodash';
 import MapsStepFieldset from './maps-step-fieldset';
 
 const styles = theme => ({
@@ -38,9 +39,15 @@ function MapsPipelineVariables(props) {
         <Divider />
         {
           consortium.pipelineSteps && consortium.pipelineSteps.map((step) => {
-            const { inputMap } = step;
+            const { computations, inputMap } = step;
 
-            return Object.keys(inputMap).map((inputMapKey) => {
+            const inputs = {...inputMap, ...computations[0].computation.input};
+
+            return Object.entries(inputs).map((input) => {
+
+              const inputMapKey = input[0];
+              const inputMapValue = input[1];
+
               if (inputMapKey === 'meta') {
                 return;
               }
@@ -49,6 +56,7 @@ function MapsPipelineVariables(props) {
                 <MapsStepFieldset
                   registerDraggableContainer={registerDraggableContainer}
                   key={`step-${inputMapKey}`}
+                  fieldsetLabel={inputMapValue.label}
                   fieldsetName={inputMapKey}
                   stepFieldset={inputMap[inputMapKey]}
                   stepsDataMappings={stepsDataMappings}

--- a/packages/coinstac-ui/app/render/components/maps/maps-step-field-covariate.jsx
+++ b/packages/coinstac-ui/app/render/components/maps/maps-step-field-covariate.jsx
@@ -69,6 +69,7 @@ class MapsStepFieldCovariate extends Component {
   render() {
     const {
       step,
+      label,
       type,
       classes,
       column,

--- a/packages/coinstac-ui/app/render/components/maps/maps-step-field-data.jsx
+++ b/packages/coinstac-ui/app/render/components/maps/maps-step-field-data.jsx
@@ -77,6 +77,7 @@ class MapsStepFieldData extends Component {
   render() {
     const {
       step,
+      label,
       type,
       classes,
       column,

--- a/packages/coinstac-ui/app/render/components/maps/maps-step-fieldset.jsx
+++ b/packages/coinstac-ui/app/render/components/maps/maps-step-fieldset.jsx
@@ -93,13 +93,16 @@ class MapsStepFieldset extends Component {
   render() {
     const {
       stepFieldset,
+      fieldsetLabel,
       fieldsetName,
       classes,
     } = this.props;
 
     let inputCategoryName = capitalize(fieldsetName);
 
-    if (fieldsetName !== 'covariates' && fieldsetName !== 'data') {
+    if(fieldsetLabel){
+      inputCategoryName = fieldsetLabel;
+    }else if (fieldsetName !== 'covariates' && fieldsetName !== 'data') {
       inputCategoryName = 'Options';
     }
 

--- a/packages/coinstac-ui/app/render/components/maps/maps-step-fieldset.jsx
+++ b/packages/coinstac-ui/app/render/components/maps/maps-step-fieldset.jsx
@@ -102,7 +102,7 @@ class MapsStepFieldset extends Component {
 
     if(fieldsetLabel){
       inputCategoryName = fieldsetLabel;
-    }else if (fieldsetName !== 'covariates' && fieldsetName !== 'data') {
+    } else if (fieldsetName !== 'covariates' && fieldsetName !== 'data') {
       inputCategoryName = 'Options';
     }
 


### PR DESCRIPTION
# Problem
dpSVM wasn't ready for primetime, it was using pickle files for data and the UI wasn't great. 

We wanted a version that used FreeSurfer data, but had a UI that made sense to researchers. 

Because of this, we needed a way to re-label 'Data' and 'Covariates' for the uI without losing their underlying keys. 

# Solution

dpSVM is now revamped with some additional work in Maps to display Covariates as 'Features' and Data as 'Labels'

# Testing

Run dpSVM with 2 or more sites. 