### PR TITLE
Hotfix: update mqtt from fork for win installs

### DIFF
--- a/packages/coinstac-pipeline/package-lock.json
+++ b/packages/coinstac-pipeline/package-lock.json
@@ -1,16 +1,20 @@
 {
-	"requires": true,
+	"name": "coinstac-pipeline",
+	"version": "4.7.4",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"@ava/babel-plugin-throws-helper": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@ava/babel-plugin-throws-helper/-/babel-plugin-throws-helper-4.0.0.tgz",
-			"integrity": "sha512-3diBLIVBPPh3j4+hb5lo0I1D+S/O/VDJPI4Y502apBxmwEqjyXG4gTSPFUlm41sSZeZzMarT/Gzovw9kV7An0w=="
+			"integrity": "sha512-3diBLIVBPPh3j4+hb5lo0I1D+S/O/VDJPI4Y502apBxmwEqjyXG4gTSPFUlm41sSZeZzMarT/Gzovw9kV7An0w==",
+			"dev": true
 		},
 		"@ava/babel-preset-stage-4": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@ava/babel-preset-stage-4/-/babel-preset-stage-4-4.0.0.tgz",
 			"integrity": "sha512-lZEV1ZANzfzSYBU6WHSErsy7jLPbD1iIgAboASPMcKo7woVni5/5IKWeT0RxC8rY802MFktur3OKEw2JY1Tv2w==",
+			"dev": true,
 			"requires": {
 				"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
 				"@babel/plugin-proposal-dynamic-import": "^7.5.0",
@@ -23,6 +27,7 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/@ava/babel-preset-transform-test-files/-/babel-preset-transform-test-files-6.0.0.tgz",
 			"integrity": "sha512-8eKhFzZp7Qcq1VLfoC75ggGT8nQs9q8fIxltU47yCB7Wi7Y8Qf6oqY1Bm0z04fIec24vEgr0ENhDHEOUGVDqnA==",
+			"dev": true,
 			"requires": {
 				"@ava/babel-plugin-throws-helper": "^4.0.0",
 				"babel-plugin-espower": "^3.0.1"
@@ -32,6 +37,7 @@
 			"version": "7.5.5",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
 			"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+			"dev": true,
 			"requires": {
 				"@babel/highlight": "^7.0.0"
 			}
@@ -40,6 +46,7 @@
 			"version": "7.6.4",
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.4.tgz",
 			"integrity": "sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
 				"@babel/generator": "^7.6.4",
@@ -61,6 +68,7 @@
 			"version": "7.6.4",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
 			"integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.6.3",
 				"jsesc": "^2.5.1",
@@ -72,6 +80,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
 			"integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0"
 			}
@@ -80,6 +89,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
 			"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-get-function-arity": "^7.0.0",
 				"@babel/template": "^7.1.0",
@@ -90,6 +100,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
 			"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0"
 			}
@@ -98,6 +109,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
 			"integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0"
 			}
@@ -106,6 +118,7 @@
 			"version": "7.5.5",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz",
 			"integrity": "sha512-jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
 				"@babel/helper-simple-access": "^7.1.0",
@@ -118,12 +131,14 @@
 		"@babel/helper-plugin-utils": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-			"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
+			"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+			"dev": true
 		},
 		"@babel/helper-regex": {
 			"version": "7.5.5",
 			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
 			"integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
+			"dev": true,
 			"requires": {
 				"lodash": "^4.17.13"
 			}
@@ -132,6 +147,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
 			"integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.0.0",
 				"@babel/helper-wrap-function": "^7.1.0",
@@ -144,6 +160,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
 			"integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
+			"dev": true,
 			"requires": {
 				"@babel/template": "^7.1.0",
 				"@babel/types": "^7.0.0"
@@ -153,6 +170,7 @@
 			"version": "7.4.4",
 			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
 			"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.4.4"
 			}
@@ -161,6 +179,7 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
 			"integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/template": "^7.1.0",
@@ -172,6 +191,7 @@
 			"version": "7.6.2",
 			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.2.tgz",
 			"integrity": "sha512-3/bAUL8zZxYs1cdX2ilEE0WobqbCmKWr/889lf2SS0PpDcpEIY8pb1CCyz0pEcX3pEb+MCbks1jIokz2xLtGTA==",
+			"dev": true,
 			"requires": {
 				"@babel/template": "^7.6.0",
 				"@babel/traverse": "^7.6.2",
@@ -182,6 +202,7 @@
 			"version": "7.5.0",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
 			"integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+			"dev": true,
 			"requires": {
 				"chalk": "^2.0.0",
 				"esutils": "^2.0.2",
@@ -191,12 +212,14 @@
 		"@babel/parser": {
 			"version": "7.6.4",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
-			"integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A=="
+			"integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
+			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
 			"integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-remap-async-to-generator": "^7.1.0",
@@ -207,6 +230,7 @@
 			"version": "7.5.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.5.0.tgz",
 			"integrity": "sha512-x/iMjggsKTFHYC6g11PL7Qy58IK8H5zqfm9e6hu4z1iH2IRyAp9u9dL80zA6R76yFovETFLKz2VJIC2iIPBuFw==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-dynamic-import": "^7.2.0"
@@ -216,6 +240,7 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
 			"integrity": "sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
@@ -225,6 +250,7 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
 			"integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -233,6 +259,7 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
 			"integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -241,6 +268,7 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
 			"integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -249,6 +277,7 @@
 			"version": "7.6.2",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.6.2.tgz",
 			"integrity": "sha512-KGKT9aqKV+9YMZSkowzYoYEiHqgaDhGmPNZlZxX6UeHC4z30nC1J9IrZuGqbYFB1jaIGdv91ujpze0exiVK8bA==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.4.4",
@@ -259,6 +288,7 @@
 			"version": "7.6.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.6.0.tgz",
 			"integrity": "sha512-Ma93Ix95PNSEngqomy5LSBMAQvYKVe3dy+JlVJSHEXZR5ASL9lQBedMiCyVtmTLraIDVRE3ZjTZvmXXD2Ozw3g==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-module-transforms": "^7.4.4",
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -270,6 +300,7 @@
 			"version": "7.6.0",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
 			"integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"@babel/parser": "^7.6.0",
@@ -280,6 +311,7 @@
 			"version": "7.6.3",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
 			"integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
 				"@babel/generator": "^7.6.3",
@@ -296,6 +328,7 @@
 			"version": "7.6.3",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
 			"integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2",
 				"lodash": "^4.17.13",
@@ -306,6 +339,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@concordance/react/-/react-2.0.0.tgz",
 			"integrity": "sha512-huLSkUuM2/P+U0uy2WwlKuixMsTODD8p4JVQBI4VKeopkiN0C7M3N9XYVawb4M+4spN5RrO/eLhk7KoQX6nsfA==",
+			"dev": true,
 			"requires": {
 				"arrify": "^1.0.1"
 			},
@@ -313,7 +347,8 @@
 				"arrify": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-					"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+					"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+					"dev": true
 				}
 			}
 		},
@@ -321,6 +356,7 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
 			"integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "2.0.3",
 				"run-parallel": "^1.1.9"
@@ -329,12 +365,14 @@
 		"@nodelib/fs.stat": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-			"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA=="
+			"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+			"dev": true
 		},
 		"@nodelib/fs.walk": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
 			"integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+			"dev": true,
 			"requires": {
 				"@nodelib/fs.scandir": "2.1.3",
 				"fastq": "^1.6.0"
@@ -343,12 +381,14 @@
 		"@sindresorhus/is": {
 			"version": "0.14.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-			"integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
+			"integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+			"dev": true
 		},
 		"@szmarczak/http-timer": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
 			"integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+			"dev": true,
 			"requires": {
 				"defer-to-connect": "^1.0.1"
 			}
@@ -356,12 +396,14 @@
 		"@types/events": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
+			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+			"dev": true
 		},
 		"@types/glob": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
 			"integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+			"dev": true,
 			"requires": {
 				"@types/events": "*",
 				"@types/minimatch": "*",
@@ -371,12 +413,14 @@
 		"@types/minimatch": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+			"dev": true
 		},
 		"@types/node": {
 			"version": "12.7.12",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
-			"integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ=="
+			"integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ==",
+			"dev": true
 		},
 		"JSONStream": {
 			"version": "1.3.2",
@@ -400,6 +444,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
 			"integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
+			"dev": true,
 			"requires": {
 				"string-width": "^3.0.0"
 			},
@@ -407,12 +452,14 @@
 				"emoji-regex": {
 					"version": "7.0.3",
 					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+					"dev": true
 				},
 				"string-width": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
 					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
 					"requires": {
 						"emoji-regex": "^7.0.1",
 						"is-fullwidth-code-point": "^2.0.0",
@@ -425,6 +472,7 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
 			"integrity": "sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==",
+			"dev": true,
 			"requires": {
 				"type-fest": "^0.5.2"
 			}
@@ -432,12 +480,14 @@
 		"ansi-regex": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+			"dev": true
 		},
 		"ansi-styles": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.1.0.tgz",
 			"integrity": "sha512-Qts4KCLKG+waHc9C4m07weIY8qyeixoS0h6RnbsNVD6Fw+pEZGW3vTyObL3WXpE09Mq4Oi7/lBEyLmOiLtlYWQ==",
+			"dev": true,
 			"requires": {
 				"color-convert": "^2.0.1"
 			},
@@ -446,6 +496,7 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
 					"requires": {
 						"color-name": "~1.1.4"
 					}
@@ -453,7 +504,8 @@
 				"color-name": {
 					"version": "1.1.4",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
 				}
 			}
 		},
@@ -461,6 +513,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
 			"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+			"dev": true,
 			"requires": {
 				"normalize-path": "^3.0.0",
 				"picomatch": "^2.0.4"
@@ -538,6 +591,7 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -545,12 +599,14 @@
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true
 		},
 		"array-find-index": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+			"dev": true
 		},
 		"array-flatten": {
 			"version": "1.1.1",
@@ -560,22 +616,26 @@
 		"array-union": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
+			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+			"dev": true
 		},
 		"array-uniq": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-2.1.0.tgz",
-			"integrity": "sha512-bdHxtev7FN6+MXI1YFW0Q8mQ8dTJc2S8AMfju+ZR77pbg2yAdVyDlwkaUI7Har0LyOMRFPHrJ9lYdyjZZswdlQ=="
+			"integrity": "sha512-bdHxtev7FN6+MXI1YFW0Q8mQ8dTJc2S8AMfju+ZR77pbg2yAdVyDlwkaUI7Har0LyOMRFPHrJ9lYdyjZZswdlQ==",
+			"dev": true
 		},
 		"arrify": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-			"integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
+			"integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+			"dev": true
 		},
 		"astral-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
+			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+			"dev": true
 		},
 		"async": {
 			"version": "2.6.3",
@@ -599,6 +659,7 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/ava/-/ava-2.4.0.tgz",
 			"integrity": "sha512-CQWtzZZZeU2g4StojRv6MO9RIRi4sLxGSB9+3C3hv0ttUEG1tkJLTLyrBQeFS4WEeK12Z4ovE3f2iPVhSy8elA==",
+			"dev": true,
 			"requires": {
 				"@ava/babel-preset-stage-4": "^4.0.0",
 				"@ava/babel-preset-transform-test-files": "^6.0.0",
@@ -679,6 +740,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
 			"integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+			"dev": true,
 			"requires": {
 				"object.assign": "^4.1.0"
 			}
@@ -687,6 +749,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-espower/-/babel-plugin-espower-3.0.1.tgz",
 			"integrity": "sha512-Ms49U7VIAtQ/TtcqRbD6UBmJBUCSxiC3+zPc+eGqxKUIFO1lTshyEDRUjhoAbd2rWfwYf3cZ62oXozrd8W6J0A==",
+			"dev": true,
 			"requires": {
 				"@babel/generator": "^7.0.0",
 				"@babel/parser": "^7.0.0",
@@ -710,7 +773,8 @@
 		"binary-extensions": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-			"integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
+			"integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+			"dev": true
 		},
 		"bl": {
 			"version": "1.2.2",
@@ -724,12 +788,14 @@
 		"bluebird": {
 			"version": "3.7.0",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.0.tgz",
-			"integrity": "sha512-aBQ1FxIa7kSWCcmKHlcHFlT2jt6J/l4FzC7KcPELkOJOsPOb/bccdhmIrKDfXhwFrmc7vDoDrrepFvGqjyXGJg=="
+			"integrity": "sha512-aBQ1FxIa7kSWCcmKHlcHFlT2jt6J/l4FzC7KcPELkOJOsPOb/bccdhmIrKDfXhwFrmc7vDoDrrepFvGqjyXGJg==",
+			"dev": true
 		},
 		"blueimp-md5": {
 			"version": "2.12.0",
 			"resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.12.0.tgz",
-			"integrity": "sha512-zo+HIdIhzojv6F1siQPqPFROyVy7C50KzHv/k/Iz+BtvtVzSHXiMXOpq2wCfNkeBqdCv+V8XOV96tsEt2W/3rQ=="
+			"integrity": "sha512-zo+HIdIhzojv6F1siQPqPFROyVy7C50KzHv/k/Iz+BtvtVzSHXiMXOpq2wCfNkeBqdCv+V8XOV96tsEt2W/3rQ==",
+			"dev": true
 		},
 		"body-parser": {
 			"version": "1.19.0",
@@ -772,6 +838,7 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/boxen/-/boxen-3.2.0.tgz",
 			"integrity": "sha512-cU4J/+NodM3IHdSL2yN8bqYqnmlBTidDR4RC7nJs61ZmtGz8VZzM3HLQX0zY5mrSmPtR3xWwsq2jOUQqFZN8+A==",
+			"dev": true,
 			"requires": {
 				"ansi-align": "^3.0.0",
 				"camelcase": "^5.3.1",
@@ -786,17 +853,20 @@
 				"camelcase": {
 					"version": "5.3.1",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
 				},
 				"emoji-regex": {
 					"version": "7.0.3",
 					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+					"dev": true
 				},
 				"string-width": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
 					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
 					"requires": {
 						"emoji-regex": "^7.0.1",
 						"is-fullwidth-code-point": "^2.0.0",
@@ -806,7 +876,8 @@
 				"type-fest": {
 					"version": "0.3.1",
 					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-					"integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
+					"integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+					"dev": true
 				}
 			}
 		},
@@ -823,6 +894,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
 			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"dev": true,
 			"requires": {
 				"fill-range": "^7.0.1"
 			}
@@ -906,6 +978,7 @@
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
 			"integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+			"dev": true,
 			"requires": {
 				"clone-response": "^1.0.2",
 				"get-stream": "^5.1.0",
@@ -920,6 +993,7 @@
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
 					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+					"dev": true,
 					"requires": {
 						"pump": "^3.0.0"
 					}
@@ -927,7 +1001,8 @@
 				"lowercase-keys": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-					"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
+					"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+					"dev": true
 				}
 			}
 		},
@@ -935,6 +1010,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-1.1.0.tgz",
 			"integrity": "sha512-IoQLeNwwf9KTNbtSA7aEBb1yfDbdnzwjCetjkC8io5oGeOmK2CBNdg0xr+tadRYKO0p7uQyZzvon0kXlZbvGrw==",
+			"dev": true,
 			"requires": {
 				"core-js": "^2.0.0",
 				"deep-equal": "^1.0.0",
@@ -945,7 +1021,8 @@
 		"call-signature": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/call-signature/-/call-signature-0.0.2.tgz",
-			"integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY="
+			"integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY=",
+			"dev": true
 		},
 		"callback-stream": {
 			"version": "1.1.0",
@@ -959,12 +1036,14 @@
 		"camelcase": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+			"dev": true
 		},
 		"camelcase-keys": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
 			"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+			"dev": true,
 			"requires": {
 				"camelcase": "^4.1.0",
 				"map-obj": "^2.0.0",
@@ -975,6 +1054,7 @@
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -985,6 +1065,7 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -992,12 +1073,14 @@
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -1008,6 +1091,7 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.2.1.tgz",
 			"integrity": "sha512-/j5PPkb5Feyps9e+jo07jUZGvkB5Aj953NrI4s8xSVScrAo/RHeILrtdb4uzR7N6aaFFxxJ+gt8mA8HfNpw76w==",
+			"dev": true,
 			"requires": {
 				"anymatch": "~3.1.1",
 				"braces": "~3.0.2",
@@ -1027,22 +1111,26 @@
 		"chunkd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/chunkd/-/chunkd-1.0.0.tgz",
-			"integrity": "sha512-xx3Pb5VF9QaqCotolyZ1ywFBgyuJmu6+9dLiqBxgelEse9Xsr3yUlpoX3O4Oh11M00GT2kYMsRByTKIMJW2Lkg=="
+			"integrity": "sha512-xx3Pb5VF9QaqCotolyZ1ywFBgyuJmu6+9dLiqBxgelEse9Xsr3yUlpoX3O4Oh11M00GT2kYMsRByTKIMJW2Lkg==",
+			"dev": true
 		},
 		"ci-info": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
+			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+			"dev": true
 		},
 		"ci-parallel-vars": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/ci-parallel-vars/-/ci-parallel-vars-1.0.0.tgz",
-			"integrity": "sha512-u6dx20FBXm+apMi+5x7UVm6EH7BL1gc4XrcnQewjcB7HWRcor/V5qWc3RG2HwpgDJ26gIi2DSEu3B7sXynAw/g=="
+			"integrity": "sha512-u6dx20FBXm+apMi+5x7UVm6EH7BL1gc4XrcnQewjcB7HWRcor/V5qWc3RG2HwpgDJ26gIi2DSEu3B7sXynAw/g==",
+			"dev": true
 		},
 		"clarify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/clarify/-/clarify-2.1.0.tgz",
 			"integrity": "sha512-sWdsTozdtoFQbmncCXqCKeUzQbEZul/WJ8xYGVJgfIf4xMEM5q0La+Gjo2MFNOVL0FfTFteHqw6JX+9M71dAdQ==",
+			"dev": true,
 			"requires": {
 				"stack-chain": "^2.0.0"
 			}
@@ -1050,22 +1138,26 @@
 		"clean-stack": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
+			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+			"dev": true
 		},
 		"clean-yaml-object": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
-			"integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g="
+			"integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g=",
+			"dev": true
 		},
 		"cli-boxes": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
-			"integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w=="
+			"integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==",
+			"dev": true
 		},
 		"cli-cursor": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
 			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+			"dev": true,
 			"requires": {
 				"restore-cursor": "^3.1.0"
 			}
@@ -1073,12 +1165,14 @@
 		"cli-spinners": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.2.0.tgz",
-			"integrity": "sha512-tgU3fKwzYjiLEQgPMD9Jt+JjHVL9kW93FiIMX/l7rivvOD4/LL0Mf7gda3+4U2KJBloybwgj5KEoQgGRioMiKQ=="
+			"integrity": "sha512-tgU3fKwzYjiLEQgPMD9Jt+JjHVL9kW93FiIMX/l7rivvOD4/LL0Mf7gda3+4U2KJBloybwgj5KEoQgGRioMiKQ==",
+			"dev": true
 		},
 		"cli-truncate": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.0.0.tgz",
 			"integrity": "sha512-C4hp+8GCIFVsUUiXcw+ce+7wexVWImw8rQrgMBFsqerx9LvvcGlwm6sMjQYAEmV/Xb87xc1b5Ttx505MSpZVqg==",
+			"dev": true,
 			"requires": {
 				"slice-ansi": "^2.1.0",
 				"string-width": "^4.1.0"
@@ -1087,12 +1181,14 @@
 		"clone": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+			"dev": true
 		},
 		"clone-response": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
 			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+			"dev": true,
 			"requires": {
 				"mimic-response": "^1.0.0"
 			}
@@ -1101,6 +1197,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-2.1.1.tgz",
 			"integrity": "sha512-tJLhH3EpFm/1x7heIW0hemXJTUU5EWl2V0EIX558jp05Mt1U6DVryCgkp3l37cxqs+DNbNgxG43SkwJXpQ14Jw==",
+			"dev": true,
 			"requires": {
 				"convert-to-spaces": "^1.0.1"
 			}
@@ -1183,7 +1280,8 @@
 		"common-path-prefix": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-1.0.0.tgz",
-			"integrity": "sha1-zVL28HEuC6q5fW+XModPIvR3UsA="
+			"integrity": "sha1-zVL28HEuC6q5fW+XModPIvR3UsA=",
+			"dev": true
 		},
 		"compress-commons": {
 			"version": "2.1.1",
@@ -1216,6 +1314,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/concordance/-/concordance-4.0.0.tgz",
 			"integrity": "sha512-l0RFuB8RLfCS0Pt2Id39/oCPykE01pyxgAFypWTlaGRgvLkZrtczZ8atEHpTeEIW+zYWXTBuA9cCSeEOScxReQ==",
+			"dev": true,
 			"requires": {
 				"date-time": "^2.1.0",
 				"esutils": "^2.0.2",
@@ -1234,6 +1333,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
 					"integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
+					"dev": true,
 					"requires": {
 						"md5-o-matic": "^0.1.1"
 					}
@@ -1244,6 +1344,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/configstore/-/configstore-4.0.0.tgz",
 			"integrity": "sha512-CmquAXFBocrzaSM8mtGPMM/HiWmyIpr4CcJl/rgY2uCObZ/S7cKU0silxslqJejl+t/T9HS8E0PUNQD81JGUEQ==",
+			"dev": true,
 			"requires": {
 				"dot-prop": "^4.1.0",
 				"graceful-fs": "^4.1.2",
@@ -1257,6 +1358,7 @@
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
 					"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+					"dev": true,
 					"requires": {
 						"is-obj": "^1.0.0"
 					}
@@ -1264,12 +1366,14 @@
 				"is-obj": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-					"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+					"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+					"dev": true
 				},
 				"make-dir": {
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
 					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -1277,12 +1381,14 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
 				},
 				"write-file-atomic": {
 					"version": "2.4.3",
 					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
 					"integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.11",
 						"imurmurhash": "^0.1.4",
@@ -1308,6 +1414,7 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
 			"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.1"
 			}
@@ -1315,7 +1422,8 @@
 		"convert-to-spaces": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz",
-			"integrity": "sha1-fj5Iu+bZl7FBfdyihoIEtNPYVxU="
+			"integrity": "sha1-fj5Iu+bZl7FBfdyihoIEtNPYVxU=",
+			"dev": true
 		},
 		"cookie-signature": {
 			"version": "1.0.6",
@@ -1325,7 +1433,8 @@
 		"core-js": {
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-			"integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+			"integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+			"dev": true
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -1365,6 +1474,7 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"dev": true,
 			"requires": {
 				"lru-cache": "^4.0.1",
 				"shebang-command": "^1.2.0",
@@ -1374,12 +1484,14 @@
 		"crypto-random-string": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
+			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+			"dev": true
 		},
 		"currently-unhandled": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+			"dev": true,
 			"requires": {
 				"array-find-index": "^1.0.1"
 			}
@@ -1397,6 +1509,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
 			"integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
+			"dev": true,
 			"requires": {
 				"time-zone": "^1.0.0"
 			}
@@ -1412,12 +1525,14 @@
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+			"dev": true
 		},
 		"decamelize-keys": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
 			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+			"dev": true,
 			"requires": {
 				"decamelize": "^1.1.0",
 				"map-obj": "^1.0.0"
@@ -1426,7 +1541,8 @@
 				"map-obj": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+					"dev": true
 				}
 			}
 		},
@@ -1471,6 +1587,7 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
 			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+			"dev": true,
 			"requires": {
 				"mimic-response": "^1.0.0"
 			}
@@ -1550,6 +1667,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.0.tgz",
 			"integrity": "sha512-ZbfWJq/wN1Z273o7mUSjILYqehAktR2NVoSrOukDkU9kg2v/Uv89yU4Cvz8seJeAmtN5oqiefKq8FPuXOboqLw==",
+			"dev": true,
 			"requires": {
 				"is-arguments": "^1.0.4",
 				"is-date-object": "^1.0.1",
@@ -1562,12 +1680,14 @@
 		"deep-extend": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+			"dev": true
 		},
 		"defaults": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
 			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+			"dev": true,
 			"requires": {
 				"clone": "^1.0.2"
 			}
@@ -1575,12 +1695,14 @@
 		"defer-to-connect": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.0.2.tgz",
-			"integrity": "sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw=="
+			"integrity": "sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw==",
+			"dev": true
 		},
 		"define-properties": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
 			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"dev": true,
 			"requires": {
 				"object-keys": "^1.0.12"
 			}
@@ -1589,6 +1711,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
 			"integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
+			"dev": true,
 			"requires": {
 				"@types/glob": "^7.1.1",
 				"globby": "^6.1.0",
@@ -1603,6 +1726,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 					"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+					"dev": true,
 					"requires": {
 						"array-uniq": "^1.0.1"
 					}
@@ -1610,12 +1734,14 @@
 				"array-uniq": {
 					"version": "1.0.3",
 					"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-					"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+					"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+					"dev": true
 				},
 				"globby": {
 					"version": "6.1.0",
 					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
 					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+					"dev": true,
 					"requires": {
 						"array-union": "^1.0.1",
 						"glob": "^7.0.3",
@@ -1627,7 +1753,8 @@
 						"pify": {
 							"version": "2.3.0",
 							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+							"dev": true
 						}
 					}
 				}
@@ -1694,6 +1821,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
 			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+			"dev": true,
 			"requires": {
 				"path-type": "^4.0.0"
 			}
@@ -1754,6 +1882,7 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.1.0.tgz",
 			"integrity": "sha512-n1oC6NBF+KM9oVXtjmen4Yo7HyAVWV2UUl50dCYJdw2924K6dX9bf9TTTWaKtYlRn0FEtxG27KS80ayVLixxJA==",
+			"dev": true,
 			"requires": {
 				"is-obj": "^2.0.0"
 			}
@@ -1761,7 +1890,8 @@
 		"duplexer3": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+			"dev": true
 		},
 		"duplexify": {
 			"version": "3.7.1",
@@ -1782,17 +1912,20 @@
 		"emittery": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.4.1.tgz",
-			"integrity": "sha512-r4eRSeStEGf6M5SKdrQhhLK5bOwOBxQhIE3YSTnZE3GpKiLfnnhE+tPtrJE79+eDJgm39BM6LSoI8SCx4HbwlQ=="
+			"integrity": "sha512-r4eRSeStEGf6M5SKdrQhhLK5bOwOBxQhIE3YSTnZE3GpKiLfnnhE+tPtrJE79+eDJgm39BM6LSoI8SCx4HbwlQ==",
+			"dev": true
 		},
 		"emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
 		},
 		"empower-core": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/empower-core/-/empower-core-1.2.0.tgz",
 			"integrity": "sha512-g6+K6Geyc1o6FdXs9HwrXleCFan7d66G5xSCfSF7x1mJDCes6t0om9lFQG3zOrzh3Bkb/45N0cZ5Gqsf7YrzGQ==",
+			"dev": true,
 			"requires": {
 				"call-signature": "0.0.2",
 				"core-js": "^2.0.0"
@@ -1827,30 +1960,33 @@
 		"equal-length": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/equal-length/-/equal-length-1.0.1.tgz",
-			"integrity": "sha1-IcoRLUirJLTh5//A5TOdMf38J0w="
+			"integrity": "sha1-IcoRLUirJLTh5//A5TOdMf38J0w=",
+			"dev": true
 		},
 		"error-ex": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+			"dev": true,
 			"requires": {
 				"is-arrayish": "^0.2.1"
 			}
 		},
 		"es5-ext": {
-			"version": "0.10.51",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.51.tgz",
-			"integrity": "sha512-oRpWzM2WcLHVKpnrcyB7OW8j/s67Ba04JCm0WnNv3RiABSvs7mrQlutB8DBv793gKcp0XENR8Il8WxGTlZ73gQ==",
+			"version": "0.10.53",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+			"integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
 			"requires": {
 				"es6-iterator": "~2.0.3",
-				"es6-symbol": "~3.1.1",
-				"next-tick": "^1.0.0"
+				"es6-symbol": "~3.1.3",
+				"next-tick": "~1.0.0"
 			}
 		},
 		"es6-error": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
+			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+			"dev": true
 		},
 		"es6-iterator": {
 			"version": "2.0.3",
@@ -1899,12 +2035,12 @@
 			}
 		},
 		"es6-symbol": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.2.tgz",
-			"integrity": "sha512-/ZypxQsArlv+KHpGvng52/Iz8by3EQPxhmbuz8yFG89N/caTFBSbcXONDw0aMjy827gQg26XAjP4uXFvnfINmQ==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+			"integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
 			"requires": {
 				"d": "^1.0.1",
-				"es5-ext": "^0.10.51"
+				"ext": "^1.1.2"
 			}
 		},
 		"escape-html": {
@@ -1915,17 +2051,20 @@
 		"escape-string-regexp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-			"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+			"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+			"dev": true
 		},
 		"esm": {
 			"version": "3.2.25",
 			"resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-			"integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+			"integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+			"dev": true
 		},
 		"espower-location-detector": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/espower-location-detector/-/espower-location-detector-1.0.0.tgz",
 			"integrity": "sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=",
+			"dev": true,
 			"requires": {
 				"is-url": "^1.2.1",
 				"path-is-absolute": "^1.0.0",
@@ -1936,12 +2075,14 @@
 		"esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true
 		},
 		"espurify": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.1.tgz",
 			"integrity": "sha512-ZDko6eY/o+D/gHCWyHTU85mKDgYcS4FJj7S+YD6WIInm7GQ6AnOjmcL4+buFV/JOztVLELi/7MmuGU5NHta0Mg==",
+			"dev": true,
 			"requires": {
 				"core-js": "^2.0.0"
 			}
@@ -1949,12 +2090,14 @@
 		"estraverse": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+			"dev": true
 		},
 		"esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"dev": true
 		},
 		"etag": {
 			"version": "1.8.1",
@@ -1974,6 +2117,7 @@
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+			"dev": true,
 			"requires": {
 				"cross-spawn": "^5.0.1",
 				"get-stream": "^3.0.0",
@@ -2046,6 +2190,21 @@
 				}
 			}
 		},
+		"ext": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+			"integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+			"requires": {
+				"type": "^2.0.0"
+			},
+			"dependencies": {
+				"type": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+					"integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
+				}
+			}
+		},
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -2054,12 +2213,14 @@
 		"fast-diff": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-			"integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
+			"integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+			"dev": true
 		},
 		"fast-glob": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.0.tgz",
 			"integrity": "sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==",
+			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
@@ -2077,6 +2238,7 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.0.tgz",
 			"integrity": "sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==",
+			"dev": true,
 			"requires": {
 				"reusify": "^1.0.0"
 			}
@@ -2098,6 +2260,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-3.0.0.tgz",
 			"integrity": "sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==",
+			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
 			},
@@ -2105,7 +2268,8 @@
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
 				}
 			}
 		},
@@ -2118,6 +2282,7 @@
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
 			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"dev": true,
 			"requires": {
 				"to-regex-range": "^5.0.1"
 			}
@@ -2155,6 +2320,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
 			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"dev": true,
 			"requires": {
 				"locate-path": "^5.0.0",
 				"path-exists": "^4.0.0"
@@ -2194,17 +2360,20 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.0.tgz",
 			"integrity": "sha512-+iXhW3LuDQsno8dOIrCIT/CBjeBWuP7PXe8w9shnj9Lebny/Gx1ZjVBYwexLz36Ri2jKuXMNpV6CYNh8lHHgrQ==",
+			"dev": true,
 			"optional": true
 		},
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
 		},
 		"get-port": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/get-port/-/get-port-5.0.0.tgz",
 			"integrity": "sha512-imzMU0FjsZqNa6BqOjbbW6w5BivHIuQKopjpPqcnx0AVHJQKCxK1O+Ab3OrVXhrekqfVMjwA9ZYu062R+KcIsQ==",
+			"dev": true,
 			"requires": {
 				"type-fest": "^0.3.0"
 			},
@@ -2212,14 +2381,16 @@
 				"type-fest": {
 					"version": "0.3.1",
 					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-					"integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
+					"integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+					"dev": true
 				}
 			}
 		},
 		"get-stream": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+			"dev": true
 		},
 		"glob": {
 			"version": "7.1.4",
@@ -2238,6 +2409,7 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
 			"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+			"dev": true,
 			"requires": {
 				"is-glob": "^4.0.1"
 			}
@@ -2282,6 +2454,7 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
 			"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+			"dev": true,
 			"requires": {
 				"ini": "^1.3.4"
 			}
@@ -2289,12 +2462,14 @@
 		"globals": {
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+			"dev": true
 		},
 		"globby": {
 			"version": "10.0.1",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
 			"integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
+			"dev": true,
 			"requires": {
 				"@types/glob": "^7.1.1",
 				"array-union": "^2.1.0",
@@ -2310,6 +2485,7 @@
 			"version": "9.6.0",
 			"resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
 			"integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+			"dev": true,
 			"requires": {
 				"@sindresorhus/is": "^0.14.0",
 				"@szmarczak/http-timer": "^1.1.2",
@@ -2328,6 +2504,7 @@
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
 					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"dev": true,
 					"requires": {
 						"pump": "^3.0.0"
 					}
@@ -2348,6 +2525,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1"
 			}
@@ -2355,22 +2533,26 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
 		},
 		"has-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+			"dev": true
 		},
 		"has-yarn": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
-			"integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw=="
+			"integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
+			"dev": true
 		},
 		"hasha": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.1.0.tgz",
 			"integrity": "sha512-OFPDWmzPN1l7atOV1TgBVmNtBxaIysToK6Ve9DK+vT6pYuklw/nPNT+HJbZi0KDcI6vWB+9tgvZ5YD7fA3CXcA==",
+			"dev": true,
 			"requires": {
 				"is-stream": "^2.0.0",
 				"type-fest": "^0.8.0"
@@ -2379,12 +2561,14 @@
 				"is-stream": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+					"dev": true
 				},
 				"type-fest": {
 					"version": "0.8.1",
 					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+					"dev": true
 				}
 			}
 		},
@@ -2402,12 +2586,14 @@
 		"hosted-git-info": {
 			"version": "2.8.5",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
-			"integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg=="
+			"integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
+			"dev": true
 		},
 		"http-cache-semantics": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
-			"integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew=="
+			"integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==",
+			"dev": true
 		},
 		"http-errors": {
 			"version": "1.7.2",
@@ -2444,22 +2630,26 @@
 		"ignore": {
 			"version": "5.1.4",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-			"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A=="
+			"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+			"dev": true
 		},
 		"ignore-by-default": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-			"integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk="
+			"integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
+			"dev": true
 		},
 		"import-lazy": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-			"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
+			"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+			"dev": true
 		},
 		"import-local": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
 			"integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+			"dev": true,
 			"requires": {
 				"pkg-dir": "^4.2.0",
 				"resolve-cwd": "^3.0.0"
@@ -2468,12 +2658,14 @@
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+			"dev": true
 		},
 		"indent-string": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"dev": true
 		},
 		"inflight": {
 			"version": "1.0.6",
@@ -2492,7 +2684,8 @@
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+			"dev": true
 		},
 		"ipaddr.js": {
 			"version": "1.9.0",
@@ -2502,7 +2695,8 @@
 		"irregular-plurals": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-2.0.0.tgz",
-			"integrity": "sha512-Y75zBYLkh0lJ9qxeHlMjQ7bSbyiSqNW/UOPWDmzC7cXskL1hekSITh1Oc6JV0XCWWZ9DE8VYSB71xocLk3gmGw=="
+			"integrity": "sha512-Y75zBYLkh0lJ9qxeHlMjQ7bSbyiSqNW/UOPWDmzC7cXskL1hekSITh1Oc6JV0XCWWZ9DE8VYSB71xocLk3gmGw==",
+			"dev": true
 		},
 		"is-absolute": {
 			"version": "1.0.0",
@@ -2516,17 +2710,20 @@
 		"is-arguments": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-			"integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
+			"integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+			"dev": true
 		},
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+			"dev": true
 		},
 		"is-binary-path": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
 			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"dev": true,
 			"requires": {
 				"binary-extensions": "^2.0.0"
 			}
@@ -2535,6 +2732,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
 			"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+			"dev": true,
 			"requires": {
 				"ci-info": "^2.0.0"
 			}
@@ -2542,12 +2740,14 @@
 		"is-date-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"dev": true
 		},
 		"is-error": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.2.tgz",
-			"integrity": "sha512-IOQqts/aHWbiisY5DuPJQ0gcbvaLFCa7fBa9xoLfxBZvQ+ZI/Zh9xoI7Gk+G64N0FdK4AbibytHht2tWgpJWLg=="
+			"integrity": "sha512-IOQqts/aHWbiisY5DuPJQ0gcbvaLFCa7fBa9xoLfxBZvQ+ZI/Zh9xoI7Gk+G64N0FdK4AbibytHht2tWgpJWLg==",
+			"dev": true
 		},
 		"is-extglob": {
 			"version": "2.1.1",
@@ -2557,12 +2757,14 @@
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"dev": true
 		},
 		"is-glob": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
 			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+			"dev": true,
 			"requires": {
 				"is-extglob": "^2.1.1"
 			}
@@ -2571,6 +2773,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
 			"integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+			"dev": true,
 			"requires": {
 				"global-dirs": "^0.1.0",
 				"is-path-inside": "^1.0.0"
@@ -2580,6 +2783,7 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
 					"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+					"dev": true,
 					"requires": {
 						"path-is-inside": "^1.0.1"
 					}
@@ -2599,32 +2803,38 @@
 		"is-npm": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-3.0.0.tgz",
-			"integrity": "sha512-wsigDr1Kkschp2opC4G3yA6r9EgVA6NjRpWzIi9axXqeIaAATPRJc4uLujXe3Nd9uO8KoDyA4MD6aZSeXTADhA=="
+			"integrity": "sha512-wsigDr1Kkschp2opC4G3yA6r9EgVA6NjRpWzIi9axXqeIaAATPRJc4uLujXe3Nd9uO8KoDyA4MD6aZSeXTADhA==",
+			"dev": true
 		},
 		"is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"dev": true
 		},
 		"is-obj": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
+			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+			"dev": true
 		},
 		"is-observable": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-2.0.0.tgz",
-			"integrity": "sha512-fhBZv3eFKUbyHXZ1oHujdo2tZ+CNbdpdzzlENgCGZUC8keoGxUew2jYFLYcUB4qo7LDD03o4KK11m/QYD7kEjg=="
+			"integrity": "sha512-fhBZv3eFKUbyHXZ1oHujdo2tZ+CNbdpdzzlENgCGZUC8keoGxUew2jYFLYcUB4qo7LDD03o4KK11m/QYD7kEjg==",
+			"dev": true
 		},
 		"is-path-cwd": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-			"integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ=="
+			"integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+			"dev": true
 		},
 		"is-path-in-cwd": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
 			"integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
+			"dev": true,
 			"requires": {
 				"is-path-inside": "^2.1.0"
 			}
@@ -2633,6 +2843,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
 			"integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
+			"dev": true,
 			"requires": {
 				"path-is-inside": "^1.0.2"
 			}
@@ -2640,12 +2851,14 @@
 		"is-plain-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+			"dev": true
 		},
 		"is-plain-object": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
 			"integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+			"dev": true,
 			"requires": {
 				"isobject": "^4.0.0"
 			}
@@ -2653,12 +2866,14 @@
 		"is-promise": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+			"dev": true
 		},
 		"is-regex": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"dev": true,
 			"requires": {
 				"has": "^1.0.1"
 			}
@@ -2679,7 +2894,8 @@
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
 		},
 		"is-unc-path": {
 			"version": "1.0.0",
@@ -2692,12 +2908,14 @@
 		"is-url": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-			"integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
+			"integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+			"dev": true
 		},
 		"is-utf8": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+			"dev": true
 		},
 		"is-windows": {
 			"version": "1.0.2",
@@ -2707,7 +2925,8 @@
 		"is-yarn-global": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
-			"integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw=="
+			"integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
+			"dev": true
 		},
 		"isarray": {
 			"version": "1.0.0",
@@ -2717,27 +2936,32 @@
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
 		},
 		"isobject": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-			"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
+			"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+			"dev": true
 		},
 		"js-string-escape": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
-			"integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8="
+			"integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=",
+			"dev": true
 		},
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
 		},
 		"js-yaml": {
 			"version": "3.13.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
 			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -2746,17 +2970,20 @@
 		"jsesc": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"dev": true
 		},
 		"json-buffer": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
+			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+			"dev": true
 		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+			"dev": true
 		},
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
@@ -2767,6 +2994,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
 			"integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+			"dev": true,
 			"requires": {
 				"minimist": "^1.2.0"
 			}
@@ -2780,6 +3008,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
 			"integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+			"dev": true,
 			"requires": {
 				"json-buffer": "3.0.0"
 			}
@@ -2796,6 +3025,7 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
 			"integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
+			"dev": true,
 			"requires": {
 				"package-json": "^6.3.0"
 			}
@@ -2817,6 +3047,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
 			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"parse-json": "^4.0.0",
@@ -2827,7 +3058,8 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
 				}
 			}
 		},
@@ -2835,6 +3067,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
 			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"dev": true,
 			"requires": {
 				"p-locate": "^4.1.0"
 			}
@@ -2847,7 +3080,8 @@
 		"lodash.clonedeep": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+			"dev": true
 		},
 		"lodash.defaults": {
 			"version": "4.2.0",
@@ -2867,12 +3101,14 @@
 		"lodash.flattendeep": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
+			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+			"dev": true
 		},
 		"lodash.islength": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/lodash.islength/-/lodash.islength-4.0.1.tgz",
-			"integrity": "sha1-Tpho1FJXXXUK/9NYyXlUPcIO1Xc="
+			"integrity": "sha1-Tpho1FJXXXUK/9NYyXlUPcIO1Xc=",
+			"dev": true
 		},
 		"lodash.isplainobject": {
 			"version": "4.0.6",
@@ -2882,7 +3118,8 @@
 		"lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+			"dev": true
 		},
 		"lodash.union": {
 			"version": "4.6.0",
@@ -2893,6 +3130,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
 			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1"
 			}
@@ -2913,6 +3151,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-2.2.0.tgz",
 			"integrity": "sha512-S0FayMXku80toa5sZ6Ro4C+s+EtFDCsyJNG/AzFMfX3AxD5Si4dZsgzm/kKnbOxHl5Cv8jBlno8+3XYIh2pNjQ==",
+			"dev": true,
 			"requires": {
 				"currently-unhandled": "^0.4.1",
 				"signal-exit": "^3.0.2"
@@ -2921,12 +3160,14 @@
 		"lowercase-keys": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+			"dev": true
 		},
 		"lru-cache": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
 			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+			"dev": true,
 			"requires": {
 				"pseudomap": "^1.0.2",
 				"yallist": "^2.1.2"
@@ -2936,6 +3177,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
 			"integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+			"dev": true,
 			"requires": {
 				"semver": "^6.0.0"
 			},
@@ -2943,19 +3185,22 @@
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
 				}
 			}
 		},
 		"map-obj": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-			"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
+			"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+			"dev": true
 		},
 		"matcher": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/matcher/-/matcher-2.0.0.tgz",
 			"integrity": "sha512-nlmfSlgHBFx36j/Pl/KQPbIaqE8Zf0TqmSMjsuddHDg6PMSVgmyW9HpkLs0o0M1n2GIZ/S2BZBLIww/xjhiGng==",
+			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^2.0.0"
 			}
@@ -2964,6 +3209,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-3.0.1.tgz",
 			"integrity": "sha512-BUiRtTtV39LIJwinWBjqVsU9xhdnz7/i889V859IBFpuqGAj6LuOvHv5XLbgZ2R7ptJoJaEcxkv88/h25T7Ciw==",
+			"dev": true,
 			"requires": {
 				"blueimp-md5": "^2.10.0"
 			}
@@ -2971,7 +3217,8 @@
 		"md5-o-matic": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-			"integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M="
+			"integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
+			"dev": true
 		},
 		"media-typer": {
 			"version": "0.3.0",
@@ -2982,6 +3229,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
 			"integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
+			"dev": true,
 			"requires": {
 				"camelcase-keys": "^4.0.0",
 				"decamelize-keys": "^1.0.0",
@@ -2998,6 +3246,7 @@
 					"version": "1.6.0",
 					"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
 					"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+					"dev": true,
 					"requires": {
 						"currently-unhandled": "^0.4.1",
 						"signal-exit": "^3.0.0"
@@ -3013,7 +3262,8 @@
 		"merge2": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
-			"integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw=="
+			"integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
+			"dev": true
 		},
 		"methods": {
 			"version": "1.1.2",
@@ -3024,6 +3274,7 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
 			"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+			"dev": true,
 			"requires": {
 				"braces": "^3.0.1",
 				"picomatch": "^2.0.5"
@@ -3050,12 +3301,14 @@
 		"mimic-fn": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"dev": true
 		},
 		"mimic-response": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+			"dev": true
 		},
 		"minimatch": {
 			"version": "3.0.4",
@@ -3074,6 +3327,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
 			"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+			"dev": true,
 			"requires": {
 				"arrify": "^1.0.1",
 				"is-plain-obj": "^1.1.0"
@@ -3082,7 +3336,8 @@
 				"arrify": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-					"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+					"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+					"dev": true
 				}
 			}
 		},
@@ -3102,8 +3357,9 @@
 			}
 		},
 		"mqtt": {
-			"version": "git+https://github.com/trendscenter/MQTT.js.git#60608c653eeb2f02cf191f1aef399fb403d73376",
-			"from": "git+https://github.com/trendscenter/MQTT.js.git",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.0.1.tgz",
+			"integrity": "sha512-sDvB/wI8e3YSSdIxJ74M81lQTFXxg1uFM5/irpQL+IH9crQiW90R69YOnk7UGj9xCqoXBBRPr8fqnkzQUKRYgg==",
 			"requires": {
 				"base64-js": "^1.3.0",
 				"commist": "^1.0.0",
@@ -3123,11 +3379,12 @@
 			}
 		},
 		"mqtt-packet": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.2.1.tgz",
-			"integrity": "sha512-ZxG5QVb7+gMix5n4DClym9dQoCZC6DoNEqgMkMi/GMXvIU4Wsdx+/6KBavw50HHFH9kN1lBSY7phxNlAS2+jnw==",
+			"version": "6.3.2",
+			"resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.3.2.tgz",
+			"integrity": "sha512-i56+2kN6F57KInGtjjfUXSl4xG8u/zOvfaXFLKFAbBXzWkXOmwcmjaSCBPayf2IQCkQU0+h+S2DizCo3CF6gQA==",
 			"requires": {
 				"bl": "^1.2.2",
+				"debug": "^4.1.1",
 				"inherits": "^2.0.3",
 				"process-nextick-args": "^2.0.0",
 				"safe-buffer": "^5.1.2"
@@ -3167,6 +3424,7 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
 			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.1.4",
 				"resolve": "^1.10.0",
@@ -3182,12 +3440,14 @@
 		"normalize-url": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-			"integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
+			"integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+			"dev": true
 		},
 		"npm-run-path": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"dev": true,
 			"requires": {
 				"path-key": "^2.0.0"
 			}
@@ -5505,17 +5765,20 @@
 		"object-is": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
-			"integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
+			"integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
+			"dev": true
 		},
 		"object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true
 		},
 		"object.assign": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
 			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"function-bind": "^1.1.1",
@@ -5527,6 +5790,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/observable-to-promise/-/observable-to-promise-1.0.0.tgz",
 			"integrity": "sha512-cqnGUrNsE6vdVDTPAX9/WeVzwy/z37vdxupdQXU8vgTXRFH72KCZiZga8aca2ulRPIeem8W3vW9rQHBwfIl2WA==",
+			"dev": true,
 			"requires": {
 				"is-observable": "^2.0.0",
 				"symbol-observable": "^1.0.4"
@@ -5557,6 +5821,7 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
 			"integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+			"dev": true,
 			"requires": {
 				"mimic-fn": "^2.1.0"
 			}
@@ -5565,6 +5830,7 @@
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
 			"integrity": "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==",
+			"dev": true,
 			"requires": {
 				"chalk": "^2.4.2",
 				"cli-cursor": "^2.1.0",
@@ -5578,6 +5844,7 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
 					"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+					"dev": true,
 					"requires": {
 						"restore-cursor": "^2.0.0"
 					}
@@ -5585,12 +5852,14 @@
 				"mimic-fn": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+					"dev": true
 				},
 				"onetime": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
 					"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+					"dev": true,
 					"requires": {
 						"mimic-fn": "^1.0.0"
 					}
@@ -5599,6 +5868,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
 					"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+					"dev": true,
 					"requires": {
 						"onetime": "^2.0.0",
 						"signal-exit": "^3.0.2"
@@ -5617,22 +5887,26 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
 		},
 		"p-cancelable": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-			"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
+			"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+			"dev": true
 		},
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+			"dev": true
 		},
 		"p-limit": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
 			"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+			"dev": true,
 			"requires": {
 				"p-try": "^2.0.0"
 			}
@@ -5641,6 +5915,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
 			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"dev": true,
 			"requires": {
 				"p-limit": "^2.2.0"
 			}
@@ -5648,17 +5923,20 @@
 		"p-map": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
+			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+			"dev": true
 		},
 		"p-try": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"dev": true
 		},
 		"package-hash": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
 			"integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.15",
 				"hasha": "^5.0.0",
@@ -5670,6 +5948,7 @@
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
 			"integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
+			"dev": true,
 			"requires": {
 				"got": "^9.6.0",
 				"registry-auth-token": "^4.0.0",
@@ -5680,7 +5959,8 @@
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
 				}
 			}
 		},
@@ -5688,6 +5968,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
 			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+			"dev": true,
 			"requires": {
 				"error-ex": "^1.3.1",
 				"json-parse-better-errors": "^1.0.1"
@@ -5696,7 +5977,8 @@
 		"parse-ms": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
-			"integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA=="
+			"integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
+			"dev": true
 		},
 		"parseurl": {
 			"version": "1.3.3",
@@ -5711,7 +5993,8 @@
 		"path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
@@ -5721,17 +6004,20 @@
 		"path-is-inside": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+			"dev": true
 		},
 		"path-key": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+			"dev": true
 		},
 		"path-parse": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"dev": true
 		},
 		"path-to-regexp": {
 			"version": "0.1.7",
@@ -5741,7 +6027,8 @@
 		"path-type": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"dev": true
 		},
 		"pend": {
 			"version": "1.2.0",
@@ -5751,12 +6038,14 @@
 		"picomatch": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
-			"integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA=="
+			"integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==",
+			"dev": true
 		},
 		"pify": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+			"dev": true
 		},
 		"pinkie": {
 			"version": "2.0.4",
@@ -5775,6 +6064,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
 			"integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
+			"dev": true,
 			"requires": {
 				"find-up": "^3.0.0",
 				"load-json-file": "^5.2.0"
@@ -5784,6 +6074,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
 					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
 					"requires": {
 						"locate-path": "^3.0.0"
 					}
@@ -5792,6 +6083,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
 					"integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
+					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.15",
 						"parse-json": "^4.0.0",
@@ -5804,6 +6096,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
 					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
 					"requires": {
 						"p-locate": "^3.0.0",
 						"path-exists": "^3.0.0"
@@ -5813,6 +6106,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
 					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
 					"requires": {
 						"p-limit": "^2.0.0"
 					}
@@ -5820,12 +6114,14 @@
 				"path-exists": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"dev": true
 				},
 				"type-fest": {
 					"version": "0.3.1",
 					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-					"integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
+					"integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+					"dev": true
 				}
 			}
 		},
@@ -5833,6 +6129,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
 			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+			"dev": true,
 			"requires": {
 				"find-up": "^4.0.0"
 			}
@@ -5841,6 +6138,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/plur/-/plur-3.1.1.tgz",
 			"integrity": "sha512-t1Ax8KUvV3FFII8ltczPn2tJdjqbd1sIzu6t4JL7nQ3EyeL/lTrj5PWKb06ic5/6XYDr65rQ4uzQEGN70/6X5w==",
+			"dev": true,
 			"requires": {
 				"irregular-plurals": "^2.0.0"
 			}
@@ -5848,12 +6146,14 @@
 		"prepend-http": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+			"dev": true
 		},
 		"pretty-ms": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-5.0.0.tgz",
 			"integrity": "sha512-94VRYjL9k33RzfKiGokPBPpsmloBYSf5Ri+Pq19zlsEcUKFob+admeXr5eFDRuPjFmEOcjJvPGdillYOJyvZ7Q==",
+			"dev": true,
 			"requires": {
 				"parse-ms": "^2.1.0"
 			}
@@ -5875,7 +6175,8 @@
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"dev": true
 		},
 		"pump": {
 			"version": "3.0.0",
@@ -5910,7 +6211,8 @@
 		"quick-lru": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
-			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
+			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+			"dev": true
 		},
 		"range-parser": {
 			"version": "1.2.1",
@@ -5932,6 +6234,7 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
 			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+			"dev": true,
 			"requires": {
 				"deep-extend": "^0.6.0",
 				"ini": "~1.3.0",
@@ -5943,6 +6246,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
 			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+			"dev": true,
 			"requires": {
 				"load-json-file": "^4.0.0",
 				"normalize-package-data": "^2.3.2",
@@ -5953,6 +6257,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
 					}
@@ -5960,7 +6265,8 @@
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
 				}
 			}
 		},
@@ -5968,6 +6274,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
 			"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+			"dev": true,
 			"requires": {
 				"find-up": "^2.0.0",
 				"read-pkg": "^3.0.0"
@@ -5977,6 +6284,7 @@
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
 					"requires": {
 						"locate-path": "^2.0.0"
 					}
@@ -5985,6 +6293,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"dev": true,
 					"requires": {
 						"p-locate": "^2.0.0",
 						"path-exists": "^3.0.0"
@@ -5994,6 +6303,7 @@
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
 					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"dev": true,
 					"requires": {
 						"p-try": "^1.0.0"
 					}
@@ -6002,6 +6312,7 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"dev": true,
 					"requires": {
 						"p-limit": "^1.1.0"
 					}
@@ -6009,12 +6320,14 @@
 				"p-try": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+					"dev": true
 				},
 				"path-exists": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"dev": true
 				}
 			}
 		},
@@ -6036,6 +6349,7 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.1.3.tgz",
 			"integrity": "sha512-ZOsfTGkjO2kqeR5Mzr5RYDbTGYneSkdNKX2fOX2P5jF7vMrd/GNnIAUtDldeHHumHUCQ3V05YfWUdxMPAsRu9Q==",
+			"dev": true,
 			"requires": {
 				"picomatch": "^2.0.4"
 			}
@@ -6044,6 +6358,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
 			"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+			"dev": true,
 			"requires": {
 				"indent-string": "^3.0.0",
 				"strip-indent": "^2.0.0"
@@ -6052,19 +6367,22 @@
 				"indent-string": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+					"dev": true
 				}
 			}
 		},
 		"regenerate": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
+			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+			"dev": true
 		},
 		"regenerate-unicode-properties": {
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
 			"integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
+			"dev": true,
 			"requires": {
 				"regenerate": "^1.4.0"
 			}
@@ -6073,6 +6391,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
 			"integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2"
 			}
@@ -6081,6 +6400,7 @@
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
 			"integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
+			"dev": true,
 			"requires": {
 				"regenerate": "^1.4.0",
 				"regenerate-unicode-properties": "^8.1.0",
@@ -6094,6 +6414,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.0.0.tgz",
 			"integrity": "sha512-lpQkHxd9UL6tb3k/aHAVfnVtn+Bcs9ob5InuFLLEDqSqeq+AljB8GZW9xY0x7F+xYwEcjKe07nyoxzEYz6yvkw==",
+			"dev": true,
 			"requires": {
 				"rc": "^1.2.8",
 				"safe-buffer": "^5.0.1"
@@ -6103,6 +6424,7 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
 			"integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+			"dev": true,
 			"requires": {
 				"rc": "^1.2.8"
 			}
@@ -6110,12 +6432,14 @@
 		"regjsgen": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
-			"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA=="
+			"integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
+			"dev": true
 		},
 		"regjsparser": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
 			"integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+			"dev": true,
 			"requires": {
 				"jsesc": "~0.5.0"
 			},
@@ -6123,7 +6447,8 @@
 				"jsesc": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
 				}
 			}
 		},
@@ -6136,6 +6461,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
 			"integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+			"dev": true,
 			"requires": {
 				"es6-error": "^4.0.1"
 			}
@@ -6148,12 +6474,14 @@
 		"require-precompiled": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/require-precompiled/-/require-precompiled-0.1.0.tgz",
-			"integrity": "sha1-WhtS63Dr7UPrmC6XTIWrWVceVvo="
+			"integrity": "sha1-WhtS63Dr7UPrmC6XTIWrWVceVvo=",
+			"dev": true
 		},
 		"resolve": {
 			"version": "1.12.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
 			"integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
@@ -6162,6 +6490,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
 			"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+			"dev": true,
 			"requires": {
 				"resolve-from": "^5.0.0"
 			}
@@ -6169,12 +6498,14 @@
 		"resolve-from": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"dev": true
 		},
 		"responselike": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
 			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+			"dev": true,
 			"requires": {
 				"lowercase-keys": "^1.0.0"
 			}
@@ -6183,6 +6514,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
 			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+			"dev": true,
 			"requires": {
 				"onetime": "^5.1.0",
 				"signal-exit": "^3.0.2"
@@ -6191,7 +6523,8 @@
 		"reusify": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
+			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+			"dev": true
 		},
 		"rimraf": {
 			"version": "2.6.3",
@@ -6204,7 +6537,8 @@
 		"run-parallel": {
 			"version": "1.1.9",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-			"integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
+			"integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+			"dev": true
 		},
 		"safe-buffer": {
 			"version": "5.1.2",
@@ -6227,12 +6561,14 @@
 		"semver": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"dev": true
 		},
 		"semver-diff": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
 			"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+			"dev": true,
 			"requires": {
 				"semver": "^5.0.3"
 			}
@@ -6282,7 +6618,8 @@
 		"serialize-error": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
-			"integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
+			"integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go=",
+			"dev": true
 		},
 		"serve-static": {
 			"version": "1.14.1",
@@ -6304,6 +6641,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"dev": true,
 			"requires": {
 				"shebang-regex": "^1.0.0"
 			}
@@ -6311,12 +6649,14 @@
 		"shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+			"dev": true
 		},
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"dev": true
 		},
 		"simple-swizzle": {
 			"version": "0.2.2",
@@ -6336,12 +6676,14 @@
 		"slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"dev": true
 		},
 		"slice-ansi": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
 			"integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.0",
 				"astral-regex": "^1.0.0",
@@ -6352,6 +6694,7 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -6361,12 +6704,14 @@
 		"source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true
 		},
 		"source-map-support": {
 			"version": "0.5.13",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
 			"integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -6375,7 +6720,8 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				}
 			}
 		},
@@ -6383,6 +6729,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
 			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+			"dev": true,
 			"requires": {
 				"spdx-expression-parse": "^3.0.0",
 				"spdx-license-ids": "^3.0.0"
@@ -6391,12 +6738,14 @@
 		"spdx-exceptions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+			"dev": true
 		},
 		"spdx-expression-parse": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"dev": true,
 			"requires": {
 				"spdx-exceptions": "^2.1.0",
 				"spdx-license-ids": "^3.0.0"
@@ -6405,7 +6754,8 @@
 		"spdx-license-ids": {
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
+			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+			"dev": true
 		},
 		"split-ca": {
 			"version": "1.0.1",
@@ -6421,9 +6771,9 @@
 			},
 			"dependencies": {
 				"readable-stream": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"requires": {
 						"inherits": "^2.0.3",
 						"string_decoder": "^1.1.1",
@@ -6435,12 +6785,14 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
 		},
 		"stack-chain": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-2.0.0.tgz",
-			"integrity": "sha512-GGrHXePi305aW7XQweYZZwiRwR7Js3MWoK/EHzzB9ROdc75nCnjSJVi21rdAGxFl+yCx2L2qdfl5y7NO4lTyqg=="
+			"integrity": "sha512-GGrHXePi305aW7XQweYZZwiRwR7Js3MWoK/EHzzB9ROdc75nCnjSJVi21rdAGxFl+yCx2L2qdfl5y7NO4lTyqg==",
+			"dev": true
 		},
 		"stack-trace": {
 			"version": "0.0.10",
@@ -6450,7 +6802,8 @@
 		"stack-utils": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
-			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA=="
+			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
+			"dev": true
 		},
 		"statuses": {
 			"version": "1.5.0",
@@ -6458,9 +6811,9 @@
 			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
 		},
 		"stream-shift": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+			"integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
 		},
 		"streamsearch": {
 			"version": "0.1.2",
@@ -6471,6 +6824,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
 			"integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
+			"dev": true,
 			"requires": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -6480,7 +6834,8 @@
 				"is-fullwidth-code-point": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
 				}
 			}
 		},
@@ -6496,6 +6851,7 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
 			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "^4.1.0"
 			}
@@ -6503,12 +6859,14 @@
 		"strip-bom": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+			"dev": true
 		},
 		"strip-bom-buf": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-2.0.0.tgz",
 			"integrity": "sha512-gLFNHucd6gzb8jMsl5QmZ3QgnUJmp7qn4uUSHNwEXumAp7YizoGYw19ZUVfuq4aBOQUtyn2k8X/CwzWB73W2lQ==",
+			"dev": true,
 			"requires": {
 				"is-utf8": "^0.2.1"
 			}
@@ -6524,22 +6882,26 @@
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+			"dev": true
 		},
 		"strip-indent": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
+			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+			"dev": true
 		},
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"dev": true
 		},
 		"supertap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/supertap/-/supertap-1.0.0.tgz",
 			"integrity": "sha512-HZJ3geIMPgVwKk2VsmO5YHqnnJYl6bV5A9JW2uzqV43WmpgliNEYbuvukfor7URpaqpxuw3CfZ3ONdVbZjCgIA==",
+			"dev": true,
 			"requires": {
 				"arrify": "^1.0.1",
 				"indent-string": "^3.2.0",
@@ -6551,22 +6913,26 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"arrify": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-					"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+					"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+					"dev": true
 				},
 				"indent-string": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+					"dev": true
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -6577,6 +6943,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
 			"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+			"dev": true,
 			"requires": {
 				"has-flag": "^4.0.0"
 			},
@@ -6584,14 +6951,16 @@
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
 				}
 			}
 		},
 		"symbol-observable": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+			"dev": true
 		},
 		"tar-fs": {
 			"version": "1.16.3",
@@ -6633,6 +7002,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
 			"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+			"dev": true,
 			"requires": {
 				"execa": "^0.7.0"
 			}
@@ -6668,7 +7038,8 @@
 		"time-zone": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
-			"integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0="
+			"integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=",
+			"dev": true
 		},
 		"to-absolute-glob": {
 			"version": "2.0.2",
@@ -6687,17 +7058,20 @@
 		"to-fast-properties": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+			"dev": true
 		},
 		"to-readable-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-			"integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q=="
+			"integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
+			"dev": true
 		},
 		"to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"dev": true,
 			"requires": {
 				"is-number": "^7.0.0"
 			}
@@ -6711,6 +7085,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/trace/-/trace-3.1.1.tgz",
 			"integrity": "sha512-iVxFnDKps8bCRQ6kXj66rHYFJY3fNkoYPHeFTFZn89YdwmmQ9Hz97IFPf3NdfbCF3zuqUqFpRNTu6N9+eZR2qg==",
+			"dev": true,
 			"requires": {
 				"stack-chain": "^2.0.0"
 			}
@@ -6718,17 +7093,20 @@
 		"trim-newlines": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-			"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
+			"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+			"dev": true
 		},
 		"trim-off-newlines": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM="
+			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
+			"dev": true
 		},
 		"trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
 		},
 		"triple-beam": {
 			"version": "1.3.0",
@@ -6743,7 +7121,8 @@
 		"type-fest": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
-			"integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw=="
+			"integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
+			"dev": true
 		},
 		"type-is": {
 			"version": "1.6.18",
@@ -6763,6 +7142,7 @@
 			"version": "3.1.5",
 			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
 			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+			"dev": true,
 			"requires": {
 				"is-typedarray": "^1.0.0"
 			}
@@ -6770,7 +7150,8 @@
 		"uid2": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-			"integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
+			"integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
+			"dev": true
 		},
 		"ultron": {
 			"version": "1.1.1",
@@ -6794,12 +7175,14 @@
 		"unicode-canonical-property-names-ecmascript": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
-			"integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ=="
+			"integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+			"dev": true
 		},
 		"unicode-match-property-ecmascript": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
 			"integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+			"dev": true,
 			"requires": {
 				"unicode-canonical-property-names-ecmascript": "^1.0.4",
 				"unicode-property-aliases-ecmascript": "^1.0.4"
@@ -6808,12 +7191,14 @@
 		"unicode-match-property-value-ecmascript": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
-			"integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g=="
+			"integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
+			"dev": true
 		},
 		"unicode-property-aliases-ecmascript": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
-			"integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw=="
+			"integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
+			"dev": true
 		},
 		"unique-stream": {
 			"version": "2.3.1",
@@ -6828,6 +7213,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
 			"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+			"dev": true,
 			"requires": {
 				"crypto-random-string": "^1.0.0"
 			}
@@ -6836,6 +7222,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unique-temp-dir/-/unique-temp-dir-1.0.0.tgz",
 			"integrity": "sha1-bc6VsmgcoAPuv7MEpBX5y6vMU4U=",
+			"dev": true,
 			"requires": {
 				"mkdirp": "^0.5.1",
 				"os-tmpdir": "^1.0.1",
@@ -6851,6 +7238,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-3.0.1.tgz",
 			"integrity": "sha512-grrmrB6Zb8DUiyDIaeRTBCkgISYUgETNe7NglEbVsrLWXeESnlCSP50WfRSj/GmzMPl6Uchj24S/p80nP/ZQrQ==",
+			"dev": true,
 			"requires": {
 				"boxen": "^3.0.0",
 				"chalk": "^2.0.1",
@@ -6870,6 +7258,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
 			"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+			"dev": true,
 			"requires": {
 				"prepend-http": "^2.0.0"
 			}
@@ -6893,6 +7282,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
 			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"dev": true,
 			"requires": {
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
@@ -6907,14 +7297,15 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
 			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+			"dev": true,
 			"requires": {
 				"defaults": "^1.0.3"
 			}
 		},
 		"websocket-stream": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/websocket-stream/-/websocket-stream-5.5.0.tgz",
-			"integrity": "sha512-EXy/zXb9kNHI07TIMz1oIUIrPZxQRA8aeJ5XYg5ihV8K4kD1DuA+FY6R96HfdIHzlSzS8HiISAfrm+vVQkZBug==",
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/websocket-stream/-/websocket-stream-5.5.2.tgz",
+			"integrity": "sha512-8z49MKIHbGk3C4HtuHWDtYX8mYej1wWabjthC/RupM9ngeukU4IWoM46dgth1UOS/T4/IqgEdCDJuMe2039OQQ==",
 			"requires": {
 				"duplexify": "^3.5.1",
 				"inherits": "^2.0.1",
@@ -6922,29 +7313,19 @@
 				"safe-buffer": "^5.1.2",
 				"ws": "^3.2.0",
 				"xtend": "^4.0.0"
-			},
-			"dependencies": {
-				"ws": {
-					"version": "3.3.3",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-					"integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
-					"requires": {
-						"async-limiter": "~1.0.0",
-						"safe-buffer": "~5.1.0",
-						"ultron": "~1.1.0"
-					}
-				}
 			}
 		},
 		"well-known-symbols": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-2.0.0.tgz",
-			"integrity": "sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q=="
+			"integrity": "sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==",
+			"dev": true
 		},
 		"which": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
 			}
@@ -6953,6 +7334,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
 			"integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+			"dev": true,
 			"requires": {
 				"string-width": "^2.1.1"
 			},
@@ -6960,12 +7342,14 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
 						"strip-ansi": "^4.0.0"
@@ -6975,6 +7359,7 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
@@ -7027,6 +7412,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.0.tgz",
 			"integrity": "sha512-EIgkf60l2oWsffja2Sf2AL384dx328c0B+cIYPTQq5q2rOYuDV00/iPFBOUiDKKwKMOhkymH8AidPaRvzfxY+Q==",
+			"dev": true,
 			"requires": {
 				"imurmurhash": "^0.1.4",
 				"is-typedarray": "^1.0.0",
@@ -7034,10 +7420,21 @@
 				"typedarray-to-buffer": "^3.1.5"
 			}
 		},
+		"ws": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+			"integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+			"requires": {
+				"async-limiter": "~1.0.0",
+				"safe-buffer": "~5.1.0",
+				"ultron": "~1.1.0"
+			}
+		},
 		"xdg-basedir": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-			"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+			"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+			"dev": true
 		},
 		"xtend": {
 			"version": "4.0.2",
@@ -7047,12 +7444,14 @@
 		"yallist": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+			"dev": true
 		},
 		"yargs-parser": {
 			"version": "10.1.0",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
 			"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+			"dev": true,
 			"requires": {
 				"camelcase": "^4.1.0"
 			}

--- a/packages/coinstac-pipeline/package.json
+++ b/packages/coinstac-pipeline/package.json
@@ -20,7 +20,7 @@
     "form-data": "^2.5.0",
     "lodash": "^4.17.10",
     "mkdirp": "^0.5.1",
-    "mqtt": "git+https://github.com/trendscenter/MQTT.js.git",
+    "mqtt": "^4.0.1",
     "multer": "^1.4.2",
     "nyc": "^11.9.0",
     "rimraf": "^2.6.2",


### PR DESCRIPTION
# Problem
Win installs of sim are failing

# Solution
It looks like the mqtt fork is causing issues w/ npm, moving to non fork for now
# Testing
`npm i -g coinstac-simulator`