### PR TITLE
Hotfix: add env replacement for dbmap

### DIFF
--- a/packages/coinstac-api-server/src/auth-helpers.js
+++ b/packages/coinstac-api-server/src/auth-helpers.js
@@ -5,20 +5,6 @@ const Promise = require('bluebird');
 const database = require('./database');
 const { transformToClient } = require('./utils');
 
-let dbmap;
-try {
-  dbmap = require('/etc/coinstac/cstacDBMap'); // eslint-disable-line import/no-absolute-path, import/no-unresolved, global-require
-} catch (e) {
-  console.log('No DBMap found: using defaults'); // eslint-disable-line no-console
-  dbmap = {
-    apiCredentials: {
-      username: 'server',
-      password: 'password',
-    },
-    cstacJWTSecret: 'test',
-  };
-}
-
 const helperFunctions = {
   /**
    * Create JWT for user signing in to application
@@ -26,7 +12,7 @@ const helperFunctions = {
    * @return {string} A JWT for the requested user
    */
   createToken(user) {
-    return jwt.sign({ username: user }, dbmap.cstacJWTSecret, { algorithm: 'HS256', expiresIn: '12h' });
+    return jwt.sign({ username: user }, process.env.API_JWT_SECRET, { algorithm: 'HS256', expiresIn: '12h' });
   },
   /**
    * Create new user account
@@ -63,11 +49,6 @@ const helperFunctions = {
 
     return result.ops[0];
   },
-  /**
-   * dbmap getter
-   * @return {Object} dbmap loaded
-   */
-  getDBMap() { return dbmap; },
   /**
    * Returns user table object for requested user
    * @param {string} username username of requested user
@@ -109,13 +90,6 @@ const helperFunctions = {
         }
       );
     });
-  },
-  /**
-   * merges the given map into the current map
-   * @param {Object} map dbmap attrs to set
-   */
-  setDBMap(map) {
-    dbmap = Object.assign({}, dbmap, map);
   },
   /**
    * Validates JWT from authenticated user
@@ -238,7 +212,6 @@ const helperFunctions = {
       });
     });
   },
-  JWTSecret: dbmap.cstacJWTSecret,
 };
 
 module.exports = helperFunctions;

--- a/packages/coinstac-api-server/src/index.js
+++ b/packages/coinstac-api-server/src/index.js
@@ -24,7 +24,7 @@ server.register(plugins, (err) => {
    */
   server.auth.strategy('jwt', 'jwt',
     {
-      key: helperFunctions.JWTSecret,
+      key: process.env.API_JWT_SECRET,
       validateFunc: helperFunctions.validateToken,
       verifyOptions: { algorithms: ['HS256'] },
     });

--- a/packages/coinstac-api-server/test/test-setup.js
+++ b/packages/coinstac-api-server/test/test-setup.js
@@ -899,10 +899,10 @@ async function populateUsers() {
   }, password);
 
   const adminPassword = await helperFunctions.hashPassword(process.argv[3]
-    || helperFunctions.getDBMap().apiCredentials.password);
+    || process.env.SERVER_API_PASSWORD);
 
   await helperFunctions.createUser({
-    username: 'server',
+    username: process.env.SERVER_API_USERNAME,
     institution: 'mrn',
     email: 'server@mrn.org',
     permissions: {

--- a/packages/coinstac-server/src/index.js
+++ b/packages/coinstac-server/src/index.js
@@ -7,18 +7,6 @@ const graphqlSchema = require('coinstac-graphql-schema');
 const routes = require('./routes');
 
 let idToken = '';
-let dbmap;
-try {
-  dbmap = require('/etc/coinstac/cstacDBMap'); // eslint-disable-line import/no-absolute-path, import/no-unresolved, global-require
-} catch (e) {
-  console.log('No DBMap found: using defaults'); // eslint-disable-line no-console
-  dbmap = {
-    apiCredentials: {
-      username: 'server',
-      password: 'password',
-    },
-  };
-}
 
 const server = new hapi.Server();
 server.connection({
@@ -32,7 +20,10 @@ const apiServer = `http://${process.env.API_SERVER_HOSTNAME}:${process.env.API_S
  */
 axios.post(
   `${apiServer}/authenticate`,
-  dbmap.apiCredentials
+	{
+		username: process.env.SERVER_API_USERNAME,
+		password: process.env.SERVER_API_PASSWORD,
+	}
 )
   .then((token) => {
     idToken = token.data.id_token;

--- a/packages/coinstac-server/src/routes/pipeline.js
+++ b/packages/coinstac-server/src/routes/pipeline.js
@@ -4,7 +4,6 @@ const path = require('path');
 const axios = require('axios');
 const graphqlSchema = require('coinstac-graphql-schema');
 const { pullImagesFromList, pruneImages } = require('coinstac-docker-manager');
-const dbmap = require('/etc/coinstac/cstacDBMap'); // eslint-disable-line import/no-absolute-path, import/no-unresolved
 
 const manager = PipelineManager.create({
   mode: 'remote',
@@ -19,7 +18,10 @@ const apiServer = `http://${process.env.API_SERVER_HOSTNAME}:${process.env.API_S
 const authenticateServer = () => {
   return axios.post(
     `${apiServer}/authenticate`,
-    dbmap.apiCredentials
+	  {
+		  username: process.env.SERVER_API_USERNAME,
+		  password: process.env.SERVER_API_PASSWORD,
+	  }
   )
     .then((token) => {
       this.id_token = token.data.id_token;

--- a/scripts/aws-secret-fetch.sh
+++ b/scripts/aws-secret-fetch.sh
@@ -52,6 +52,10 @@ if [ $3 = export ]; then
   echo "export MQTT_SERVER_PATHNAME=$(echo $CONFIG | jq -r .MQTT_SERVER_PATHNAME)"
   echo "export MQTT_SERVER_PORT=$(echo $CONFIG | jq -r .MQTT_SERVER_PORT)"
   echo "export MQTT_SERVER_PROTOCOL=$(echo $CONFIG | jq -r .MQTT_SERVER_PROTOCOL)"
+  echo "export API_JWT_SECRET=$(echo $CONFIG | jq -r .API_JWT_SECRET)"
+  echo "export SERVER_API_USERNAME=$(echo $CONFIG | jq -r .SERVER_API_USERNAME)"
+  echo "export SERVER_API_PASSWORD=$(echo $CONFIG | jq -r .SERVER_API_PASSWORD)"
+
 elif [ $3 = systemd ]; then
   echo "CLOUDINARY_UPLOAD_PRESET=$(echo $CONFIG | jq -r .CLOUDINARY_UPLOAD_PRESET)"
   echo "CLOUDINARY_API_KEY=$(echo $CONFIG | jq -r .CLOUDINARY_API_KEY)"
@@ -71,6 +75,9 @@ elif [ $3 = systemd ]; then
   echo "MQTT_SERVER_PATHNAME=$(echo $CONFIG | jq -r .MQTT_SERVER_PATHNAME)"
   echo "MQTT_SERVER_PORT=$(echo $CONFIG | jq -r .MQTT_SERVER_PORT)"
   echo "MQTT_SERVER_PROTOCOL=$(echo $CONFIG | jq -r .MQTT_SERVER_PROTOCOL)"
+  echo "API_JWT_SECRET=$(echo $CONFIG | jq -r .API_JWT_SECRET)"
+  echo "SERVER_API_USERNAME=$(echo $CONFIG | jq -r .SERVER_API_USERNAME)"
+  echo "SERVER_API_PASSWORD=$(echo $CONFIG | jq -r .SERVER_API_PASSWORD)"
 else
   echo $CONFIG
 fi


### PR DESCRIPTION
# Problem
Forgot dbmap (how could I) with the config changes

# Solution
* bye bye dbmap
# Testing
`npm run devdata` in root was the previous missing testing piece 