### PR TITLE
Tooling: add docker image to do platform independant builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ packages/coinstac-ui/coinstac-win32*
 packages/coinstac-ui/coinstac-mas*
 
 packages/coinstac-ui/config/local-build-copy.json
+build/

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "watch": "cd packages/coinstac-ui/ && npm run watch",
     "start": "concurrently \"npm run api-server\" \"sleep 6 && npm run server\" \"npm run watch\" ",
     "build": "lerna bootstrap",
-    "build-app": "mkdir -p ./build && scripts/dockerbuild.sh $1",
+    "build-app": "mkdir -p ./build && docker pull coinstacteam/coinstac && scripts/dockerbuild.sh $1",
     "build:server": "lerna bootstrap --ignore 'coinstac-{client-core,decentralized-algorithm-integration,simulator,storage-proxy,ui}'",
     "clean": "lerna clean",
     "clean:comps": "rm -rf packages/coinstac-computation-registry/node_modules/{laplacian-noise,decentralized-single-shot}-ridge-regression",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "watch": "cd packages/coinstac-ui/ && npm run watch",
     "start": "concurrently \"npm run api-server\" \"sleep 6 && npm run server\" \"npm run watch\" ",
     "build": "lerna bootstrap",
+    "build-app": "mkdir -p ./build && scripts/dockerbuild.sh $1",
     "build:server": "lerna bootstrap --ignore 'coinstac-{client-core,decentralized-algorithm-integration,simulator,storage-proxy,ui}'",
     "clean": "lerna clean",
     "clean:comps": "rm -rf packages/coinstac-computation-registry/node_modules/{laplacian-noise,decentralized-single-shot}-ridge-regression",

--- a/packages/coinstac-ui/package.json
+++ b/packages/coinstac-ui/package.json
@@ -128,7 +128,7 @@
   },
   "scripts": {
     "build:webpack": "cross-env NODE_ENV=production webpack --mode=production",
-    "build": "npm i && npm run build:webpack && node ./scripts/build.js production",
+    "build-prod": "npm i && npm run build:webpack && node ./scripts/build.js production",
     "build-dev": "npm i && node ./scripts/build-setup.js  && npm dedupe && npm run build:webpack && node ./scripts/build.js development",
     "build-local": "npm i && node ./scripts/build-setup.js && npm dedupe && npm run build:webpack && node ./scripts/build.js",
     "start": "electron . --log-level=debug",

--- a/scripts/dockerbuild.sh
+++ b/scripts/dockerbuild.sh
@@ -1,0 +1,1 @@
+docker run -it -v $(pwd)/build:/usr/local/src/coinstac/packages/coinstac-ui/build/apps --rm coinstacteam/coinstac /bin/bash -c "cd packages/coinstac-ui && npm run build-${1}"


### PR DESCRIPTION
# Problem
* there is no platform dependent way to make builds

# Solution
* make a docker images to run builds
# Testing
`npm run build-app` in root