### PR TITLE
Sim: fix there being no debug info on comp errors

### DIFF
--- a/packages/coinstac-pipeline/src/pipeline-manager.js
+++ b/packages/coinstac-pipeline/src/pipeline-manager.js
@@ -533,11 +533,10 @@ module.exports = {
 
             // normal pipeline operation
             if (remoteClients[id] && remoteClients[id][runId]) {
-              remoteClients[id][runId].debug.received = Date.now();
-              remoteClients[id][runId].debug.sent = data.debug.sent;
-
               // is the client giving us an error?
               if (!error) {
+                remoteClients[id][runId].debug.received = Date.now();
+                remoteClients[id][runId].debug.sent = data.debug.sent;
                 // has this pipeline error'd out?
                 if (!activePipelines[runId].error) {
                   // check if the msg is a dup, either for a current or past iteration


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](../CONTRIBUTING.md)
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Passes e2e testing
- [x] Passes lint
- [x] Docs have been added / updated if neccessary (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bugfix for sim debug mode

* **What is the current behavior?** (You can also link to an open issue here)
referenced issue(s):
on sim error, the sim would try to access debug info that was not there


* **What is the new behavior (if this is a feature change)?**

only access debug info on successful runs

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

n/a

