### PR TITLE
Add notification on startup to map data

### DIFF
--- a/packages/coinstac-ui/app/render/components/dashboard/listeners/start-pipeline-listener.jsx
+++ b/packages/coinstac-ui/app/render/components/dashboard/listeners/start-pipeline-listener.jsx
@@ -50,6 +50,7 @@ class StartPipelineListener extends React.Component {
       localRunResults,
       consortia,
       maps,
+      notifyInfo,
     } = this.props;
 
     remoteRuns.forEach((remoteRun) => {
@@ -64,6 +65,11 @@ class StartPipelineListener extends React.Component {
       const consortium = consortia.find(c => c.id === remoteRun.consortiumId);
       const dataMapping = maps.find(m => m.consortiumId === consortium.id
         && m.pipelineId === consortium.activePipelineId);
+
+      if (!dataMapping) {
+        notifyInfo(`Run for ${consortium.name} is waiting for your data. Please map your data to take part of the consortium.`);
+        return;
+      }
 
       this.startPipeline(consortium, dataMapping, remoteRun);
     });


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](../CONTRIBUTING.md)
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [] Tests for the changes have been added (for bug fixes / features)
- [x] Passes e2e testing
- [x] Passes lint
- [x] Docs have been added / updated if neccessary (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add notification for when the user logs in and is not mapped for a run that he' a part of.

* **What is the current behavior?** (You can also link to an open issue here)
Currently if the user logs in and does not have mapped data, the app starts the local run and errors out because of the lack of data.

* **What is the new behavior (if this is a feature change)?**
A notification appears asking for the user to map data to take part on the run.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no
