### PR TITLE
fix/ show private consortia to members

### DIFF
--- a/packages/coinstac-api-server/src/data/resolvers.js
+++ b/packages/coinstac-api-server/src/data/resolvers.js
@@ -247,7 +247,7 @@ const resolvers = {
       const consortia = await db.collection('consortia').find({
         $or: [
           { isPrivate: false },
-          { members: credentials.username }
+          { members: {[credentials.id]:credentials.username} }
         ]
       }).toArray();
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](../CONTRIBUTING.md)
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Passes e2e testing
- [ ] Passes lint
- [ ] Docs have been added / updated if neccessary (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
referenced issue(s):
https://github.com/trendscenter/coinstac/issues/1129
Private consortia would not show up in the ui, even if the user was a member.


* **What is the new behavior (if this is a feature change)?**
Private consortia are now returned if the user is a member


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
