### PR TITLE
API: fix race condition between seed data and db drop

### DIFF
--- a/packages/coinstac-api-server/seed/populate.js
+++ b/packages/coinstac-api-server/seed/populate.js
@@ -252,7 +252,7 @@ async function populatePipelines() {
 async function populateRuns() {
   const db = database.getDbInstance();
 
-  db.collection('runs').insertMany([
+  return db.collection('runs').insertMany([
     {
       _id: RUN_IDS[0],
       clients: {

--- a/packages/coinstac-api-server/seed/populate.js
+++ b/packages/coinstac-api-server/seed/populate.js
@@ -1216,8 +1216,9 @@ async function populateDatasets() {
 async function populate(closeConnection = true) {
   await database.connect();
 
-  database.dropDbInstance();
-
+  await database.dropDbInstance();
+  database.getDbInstance();
+  await database.createDbIndexes();
   await populateComputations();
   await populateConsortia();
   await populatePipelines();

--- a/packages/coinstac-api-server/src/database/index.js
+++ b/packages/coinstac-api-server/src/database/index.js
@@ -14,21 +14,21 @@ async function connect() {
 
 function createDbInstance() {
   db = client.db(process.env.DATABASE_NAME);
-
-  db.collection('users').createIndex({ username: 1 }, { unique: true });
-  db.collection('users').createIndex({ email: 1 }, { unique: true });
-
-  db.collection('headlessClients').createIndex({ name: 1 }, { unique: true });
-
-  db.collection('datasets').createIndex({ '$**': 'text' });
 }
 
-function dropDbInstance() {
+async function createDbIndexes() {
+  await db.collection('users').createIndex({ username: 1 }, { unique: true });
+  await db.collection('users').createIndex({ email: 1 }, { unique: true });
+  await db.collection('headlessClients').createIndex({ name: 1 }, { unique: true });
+  await db.collection('datasets').createIndex({ '$**': 'text' });
+}
+
+async function dropDbInstance() {
   if (!db) {
     createDbInstance();
   }
 
-  db.dropDatabase();
+  await db.dropDatabase();
   db = null;
 }
 
@@ -54,4 +54,5 @@ module.exports = {
   dropDbInstance,
   getDbInstance,
   createUniqueId,
+  createDbIndexes,
 };

--- a/packages/coinstac-api-server/tests/resolvers.test.js
+++ b/packages/coinstac-api-server/tests/resolvers.test.js
@@ -885,6 +885,6 @@ test('createIssue', async (t) => {
 });
 
 test.after.always('cleanup', async () => {
-  database.dropDbInstance();
+  await database.dropDbInstance();
   await database.close();
 });


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](../CONTRIBUTING.md)
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Passes e2e testing
- [x] Passes lint
- [x] Docs have been added / updated if necessary (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
The promise returned by the db drop func was being ignored, causing a race condition between it and the seed data


* **What is the current behavior?** (You can also link to an open issue here)
An occasional race condition that manifests as impartial seed data


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
