### PR TITLE
Preserve map after pipeline edit if member inputs didn't change

### DIFF
--- a/packages/coinstac-ui/app/render/components/pipelines/pipeline.jsx
+++ b/packages/coinstac-ui/app/render/components/pipelines/pipeline.jsx
@@ -61,7 +61,6 @@ import {
   isPipelineOwner,
   getGraphQLErrorMessage,
   isUserInGroup,
-  reducePipelineInputs,
 } from '../../utils/helpers';
 import STEPS from '../../constants/tutorial';
 
@@ -552,14 +551,7 @@ class Pipeline extends Component {
         savingStatus: 'success',
       });
 
-      if (oldPipeline) {
-        const oldPipelineInputs = reducePipelineInputs(oldPipeline);
-        const newPipelineInputs = reducePipelineInputs(newPipeline);
-
-        if (oldPipelineInputs.length !== newPipelineInputs) {
-          updateMapStatus(newPipeline.owningConsortium, newPipeline.id, false);
-        }
-      }
+      updateMapStatus(newPipeline.owningConsortium, newPipeline);
 
       notifySuccess('Pipeline Saved');
 

--- a/packages/coinstac-ui/app/render/state/ducks/maps.js
+++ b/packages/coinstac-ui/app/render/state/ducks/maps.js
@@ -1,7 +1,10 @@
 /* eslint-disable no-case-declarations */
 import { dirname, basename } from 'path';
+import isEqual from 'lodash/isEqual';
+
 import { applyAsyncLoading } from './loading';
 import { startRun } from './runs';
+import { getAllUnfulfilledPipelineInputs } from '../../utils/helpers';
 
 const fs = require('fs');
 const path = require('path');
@@ -105,6 +108,7 @@ export const saveDataMapping = applyAsyncLoading(
     const mapping = {
       consortiumId: consortium.id,
       pipelineId: pipeline.id,
+      pipelineSnapshot: pipeline,
       map: mapData,
       dataMap: map,
       isComplete: true,
@@ -127,14 +131,40 @@ export const saveDataMapping = applyAsyncLoading(
   }
 );
 
+// Called when a pipeline is edited to update the map status accordingly
 export const updateMapStatus = applyAsyncLoading(
-  (consortiumId, pipelineId, complete) => async (dispatch) => {
+  (consortiumId, pipeline) => async (dispatch, getState) => {
+    const { maps } = getState();
+
+    const currentMap = maps.consortiumDataMappings.find(
+      m => m.consortiumId === consortiumId && m.pipelineId === pipeline.id
+    );
+
+    if (!currentMap) return;
+
+    if (!currentMap.pipelineSnapshot) {
+      return dispatch({
+        type: UPDATE_MAP_STATUS,
+        payload: {
+          consortiumId,
+          pipelineId: pipeline.id,
+          complete: false,
+        },
+      });
+    }
+
+    const newPipelineInputs = getAllUnfulfilledPipelineInputs(pipeline);
+    const oldPipelineInputs = getAllUnfulfilledPipelineInputs(currentMap.pipelineSnapshot);
+
+    const unfulfilledInputsAreEqual = isEqual(newPipelineInputs, oldPipelineInputs);
+
     dispatch(({
       type: UPDATE_MAP_STATUS,
       payload: {
         consortiumId,
-        pipelineId,
-        complete,
+        pipelineId: pipeline.id,
+        pipelineSnapshot: pipeline,
+        complete: unfulfilledInputsAreEqual,
       },
     }));
   }
@@ -196,6 +226,7 @@ export default function reducer(state = INITIAL_STATE, action) {
               return {
                 ...map,
                 isComplete: action.payload.complete,
+                pipelineSnapshot: action.payload.pipelineSnapshot,
               };
             }
 

--- a/packages/coinstac-ui/app/render/utils/helpers.js
+++ b/packages/coinstac-ui/app/render/utils/helpers.js
@@ -29,28 +29,22 @@ export function pipelineNeedsDataMapping(pipeline) {
   return needsDataMapping;
 }
 
-export function reducePipelineInputs(pipeline) {
+export function getAllUnfulfilledPipelineInputs(pipeline) {
   if (!pipeline || !pipeline.steps) {
     return [];
   }
 
-  const reducedInputs = pipeline.steps.reduce((inputs, step) => {
-    const inputsArray = [...inputs];
-
+  const reducedInputs = pipeline.steps.reduce((unfulfilledInputs, step) => {
     Object.keys(step.inputMap).forEach((inputMapKey) => {
       if (step.inputMap[inputMapKey].fulfilled) {
         return;
       }
 
-      if (Array.isArray(step.inputMap[inputMapKey].value)) {
-        inputsArray.push(...step.inputMap[inputMapKey].value);
-      } else {
-        inputsArray.push(step.inputMap[inputMapKey].value);
-      }
+      unfulfilledInputs[inputMapKey] = step.inputMap[inputMapKey];
     });
 
-    return inputsArray;
-  }, []);
+    return unfulfilledInputs;
+  }, {});
 
   return reducedInputs;
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](../CONTRIBUTING.md)
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [] Tests for the changes have been added (for bug fixes / features)
- [x] Passes e2e testing
- [] Passes lint
- [] Docs have been added / updated if necessary (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Preserve map after pipeline edit if member inputs didn't change


* **What is the current behavior?** (You can also link to an open issue here)
All pipeline changes resulted in the user needing to re-map member inputs



* **What is the new behavior (if this is a feature change)?**
Avoid remapping when member inputs didn't change


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
