### PR TITLE
Windows network drive users notify need admin

### DIFF
--- a/packages/coinstac-ui/app/render/components/user/settings.jsx
+++ b/packages/coinstac-ui/app/render/components/user/settings.jsx
@@ -74,6 +74,9 @@ const styles = theme => ({
     alignItems: 'center',
     marginTop: theme.spacing(2),
   },
+  warning: {
+    color: 'red',
+  },
 });
 
 class Settings extends Component {
@@ -265,6 +268,16 @@ class Settings extends Component {
             value={networkVolume}
             onChange={this.handleNetworkVolumeChange}
           />
+        </div>
+        <div>
+          {networkVolume
+            && (
+            <Typography variant="subtitle1" className={classes.warning}>
+              To use network volumes on Windows users must run the COINSTAC application with administrator priviledges
+            </Typography>
+            )
+          }
+
         </div>
 
         <Typography variant="h5" className={classes.topMargin}>

--- a/packages/coinstac-ui/app/render/components/user/settings.jsx
+++ b/packages/coinstac-ui/app/render/components/user/settings.jsx
@@ -274,6 +274,7 @@ class Settings extends Component {
             && (
             <Typography variant="subtitle1" className={classes.warning}>
               To use network volumes on Windows users must run the COINSTAC application with administrator priviledges
+              or have Windows Developer Mode enabled
             </Typography>
             )
           }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](../CONTRIBUTING.md)
- [x] Passes e2e testing
- [x] Passes lint



* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
closes _issue #1273 



* **What is the new behavior (if this is a feature change)?**
When a user enables network drives text appears letting them know to use admin mode if they are on a Windows machine.

