### PR TITLE
Bugfix: server --no-images flag not working

### DIFF
--- a/packages/coinstac-server/src/index.js
+++ b/packages/coinstac-server/src/index.js
@@ -27,7 +27,7 @@ const apiServer = `http://${process.env.API_SERVER_HOSTNAME}:${process.env.API_S
  * @return {Promise<string>} Success flag
  */
 let startup = Promise.resolve();
-if (!program.noImages) {
+if (program.opts().images) {
   startup = axios.post(
     `${apiServer}/authenticate`,
     {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* **Please check if the PR fulfills these requirements**

- [ ] Passes e2e testing
- [ ] Passes lint


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


* **What is the current behavior?** (You can also link to an open issue here)
running `coinstac-server` with the `--no-images` or `-n` flag does not prevent docker images from being downloaded automatically.



* **What is the new behavior (if this is a feature change)?**
running `coinstac-server` with the `--no-images` or `-n` flag prevents docker images from being downloaded automatically.


