### PR TITLE
Remove max auth token age

### DIFF
--- a/packages/coinstac-api-server/src/index.js
+++ b/packages/coinstac-api-server/src/index.js
@@ -78,8 +78,6 @@ async function startServer() {
         sub: helperFunctions.subject,
         nbf: true,
         exp: true,
-        maxAgeSec: 43200, // 24 hours
-        timeSkewSec: 15,
       },
     });
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](../CONTRIBUTING.md)
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Passes e2e testing
- [x] Passes lint
- [ ] Docs have been added / updated if necessary (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Auth token have a max age of 24h



* **What is the new behavior (if this is a feature change)?**
The expire time is checked against the expire field set into the JWT only. Removed max age for tokens.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no


* **Other information**:
