### PR TITLE
Updating SETUP.md to remove 'windows-build-tools'

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -6,21 +6,12 @@ These instructions explain how to get COINSTAC up and running on your machine fo
 
 You’ll need some software installed:
 
-1. **Build tools,** namely g++/gcc.
-  * OS X: The easiest way to install Xcode through Apple’s App Store. (You can try [installing the command line tools](https://www.maketecheasier.com/install-command-line-tools-without-xcode/))
-  * Linux: `apt-get install build-essential` for Ubuntu-flavored versions. Check your distro for details.
-  * Windows: requires npm to be installed first (go to step 3) `npm install --global windows-build-tools`
-2. **Install git.** See https://git-scm.com/download. You may also try [GitHub’s desktop client](https://desktop.github.com/): see [their post for CLI instructions](https://github.com/blog/1510-installing-git-from-github-for-mac).
-3. **Install Node.js**. Coinstac only supports the latest LTS version of Nodejs. You can enter `node -v` to find out which version you have.
-   * Consider using a Node.js version manager if you already have a version of Node.js installed.
-     * Mac/Linux: [n](https://www.npmjs.com/package/n)
-     * Windows: [nvm-windows](https://github.com/coreybutler/nvm-windows)
-   * Download the latest LTS build from [nodejs.org](https://nodejs.org/)
-   * Windows: configure npm to use Git Bash for executing scripts 
-     * `npm config set script-shell "C:\\Program Files\\git\\bin\\bash.exe"`
+1. **Lerna,** a manager for the packages in the COINSTAC repository.
+  * With npm to be installed first (go to step 3), run `npm install --global lerna`
 
-4. Install a MQTT client, any will work listening on localhost and the standard mqtt port (1883). We prefer [mosquitto](https://mosquitto.org/) but any client should work. Mosquitto is available on `brew` and `apt`.
-5. To run computations and have the UI not complain, you'll need [Docker](https://docs.docker.com/get-docker/). Docker memory requirements differ per computation, but 4gb is recommended as a minimum and 12gb will allow most any computation to run.
+2. Install a MQTT client, any will work listening on localhost and the standard mqtt port (1883). We prefer [mosquitto](https://mosquitto.org/) but any client should work. Mosquitto is available on `brew` and `apt`.
+
+4. To run computations and have the UI not complain, you'll need [Docker](https://docs.docker.com/get-docker/). Docker memory requirements differ per computation, but 4gb is recommended as a minimum and 12gb will allow most any computation to run.
 
 
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -6,10 +6,13 @@ These instructions explain how to get COINSTAC up and running on your machine fo
 
 You’ll need some software installed:
 
-1. **Lerna,** a manager for the packages in the COINSTAC repository.
+2. **npm,** a package manager for Node.js
+* See detailed instructions here: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
+
+2. **Lerna,** a manager for the packages in the COINSTAC repository.
   * With npm to be installed first (go to step 3), run `npm install --global lerna`
 
-2. Install a MQTT client, any will work listening on localhost and the standard mqtt port (1883). We prefer [mosquitto](https://mosquitto.org/) but any client should work. Mosquitto is available on `brew` and `apt`.
+3. Install a MQTT client, any will work listening on localhost and the standard mqtt port (1883). We prefer [mosquitto](https://mosquitto.org/) but any client should work. Mosquitto is available on `brew` and `apt`.
 
 4. To run computations and have the UI not complain, you'll need [Docker](https://docs.docker.com/get-docker/). Docker memory requirements differ per computation, but 4gb is recommended as a minimum and 12gb will allow most any computation to run.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -6,11 +6,22 @@ These instructions explain how to get COINSTAC up and running on your machine fo
 
 You’ll need some software installed:
 
-1. **npm,** a package manager for Node.js
+1. **Node and npm** COINSTAC only supports the latest LTS version of Node, and so using a Node version manager is strongly recommended
 * See detailed instructions here: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
+* If you are running Windows, you need to set npm to use the Git Bash shell. Run the following command, replacing the path with the bath to whever your local 'git-bash.exe' is installed. 
+
+```shell
+npm config set script-shell "C:\Program Files\Git\git-bash.exe"
+```
+
+* You can verify that you have set this up correctly by running
+
+```shell
+npm config ls
+```
 
 2. **Lerna,** a manager for the packages in the COINSTAC repository.
-  * With npm to be installed first, run `npm install --global lerna`
+  * With npm installed, run `npm install --global lerna`
 
 3. Install a MQTT client, any will work listening on localhost and the standard mqtt port (1883). We prefer [mosquitto](https://mosquitto.org/) but any client should work. Mosquitto is available on `brew` and `apt`.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -8,7 +8,8 @@ You’ll need some software installed:
 
 1. **Node and npm** COINSTAC only supports the latest LTS version of Node, and so using a Node version manager is strongly recommended
 * See detailed instructions here: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
-* If you are running Windows, you need to set npm to use the Git Bash shell. Run the following command, replacing the path with the bath to whever your local 'git-bash.exe' is installed. 
+* If you are running Windows, you will need to download and install Git Bash. You can do that here: https://git-scm.com/download/win
+* Windows users will then need to configure npm to use the Git Bash shell while working with COINSTAC. Run the following command, replacing the path with the bath to whever your local 'git-bash.exe' is installed. 
 
 ```shell
 npm config set script-shell "C:\Program Files\Git\git-bash.exe"
@@ -18,6 +19,11 @@ npm config set script-shell "C:\Program Files\Git\git-bash.exe"
 
 ```shell
 npm config ls
+```
+* You should see a configuration called 'script-shell' set to the directory you specified. If you have issues with the commands above, you can edit npm's configuration file directly with
+
+```shell
+npm config edit
 ```
 
 2. **Lerna,** a manager for the packages in the COINSTAC repository.

--- a/SETUP.md
+++ b/SETUP.md
@@ -10,7 +10,7 @@ You’ll need some software installed:
 * See detailed instructions here: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
 
 2. **Lerna,** a manager for the packages in the COINSTAC repository.
-  * With npm to be installed first (go to step 3), run `npm install --global lerna`
+  * With npm to be installed first, run `npm install --global lerna`
 
 3. Install a MQTT client, any will work listening on localhost and the standard mqtt port (1883). We prefer [mosquitto](https://mosquitto.org/) but any client should work. Mosquitto is available on `brew` and `apt`.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -6,7 +6,7 @@ These instructions explain how to get COINSTAC up and running on your machine fo
 
 You’ll need some software installed:
 
-2. **npm,** a package manager for Node.js
+1. **npm,** a package manager for Node.js
 * See detailed instructions here: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
 
 2. **Lerna,** a manager for the packages in the COINSTAC repository.


### PR DESCRIPTION

* **What kind of change does this PR introduce?**

Updated SETUP.md to remove references to 'windows-build-tools'

* **Why?** 
'windows-build-tools' is a troublesome installation for many people, and even throws a warning that it is deprecated when using npm, which comes with build tools. Of the items that come with windows-build-tools, only 'lerna' seemed to be necessary to complete the COINSTAC installation, so this PR recommends users install lerna alone to avoid possible trouble with windows-build-tools

Lerna can also be executed via npx, but I haven't included that here.




